### PR TITLE
Organize test suite into focused modules

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,26 @@
+import pytest
+
+import src.main as main
+
+
+def test_load_config_success(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "cfg.yml"
+    cfg_file.write_text("foo: 1")
+    monkeypatch.setattr(main, "CONFIG_PATH", str(cfg_file))
+    assert main.load_config() == {"foo": 1}
+
+
+def test_load_config_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "CONFIG_PATH", str(tmp_path / "nonexistent.yml"))
+    with pytest.raises(FileNotFoundError):
+        main.load_config()
+
+
+def test_get_api_credentials_success():
+    cfg = {"api_id": "123", "api_hash": "hash", "session": "sess"}
+    assert main.get_api_credentials(cfg) == (123, "hash", "sess")
+
+
+def test_get_api_credentials_missing():
+    with pytest.raises(RuntimeError):
+        main.get_api_credentials({})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,21 +72,3 @@ def test_load_instances_backward_compat():
     assert inst.target_chat == 2
 
 
-@pytest.mark.asyncio
-async def test_get_entity_name_with_cache_and_client(monkeypatch):
-    calls = []
-
-    class DummyClient:
-        async def get_entity(self, ident):
-            calls.append(ident)
-            return SimpleNamespace(title="Chat Name")
-
-    main.client = DummyClient()
-    main.entity_name_cache.clear()
-
-    name = await main.get_entity_name("id1")
-    assert name == "Chat_Name"
-    # Second call should hit cache and not call client again
-    name2 = await main.get_entity_name("id1")
-    assert name2 == "Chat_Name"
-    assert calls == ["id1"]

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -7,41 +7,6 @@ import pytest
 import src.main as main
 
 
-class DummyClientForList:
-    def __init__(self, filters):
-        self.connected = False
-        self.filters = filters
-        self.calls = []
-
-    def is_connected(self):
-        return self.connected
-
-    async def connect(self):
-        self.connected = True
-        self.calls.append("connect")
-
-    async def __call__(self, req):
-        self.calls.append("request")
-        return SimpleNamespace(filters=self.filters)
-
-
-def create_filter():
-    from telethon import types
-
-    return types.DialogFilter(id=1, title=None, pinned_peers=[], include_peers=[], exclude_peers=[])
-
-
-@pytest.mark.asyncio
-async def test_list_folders_connect(monkeypatch):
-    f = create_filter()
-    client = DummyClientForList([f])
-    monkeypatch.setattr(main, "client", client)
-    result = await main.list_folders()
-    assert client.connected is True
-    assert client.calls == ["connect", "request"]
-    assert result == [f]
-
-
 class BreakLoop(Exception):
     pass
 
@@ -110,6 +75,7 @@ async def test_main_flow(monkeypatch):
 
     dummy_client = DummyTG()
     monkeypatch.setattr(main, "TelegramClient", lambda s, a, b: dummy_client)
+
     async def fake_rescan(inst):
         return None
 
@@ -125,6 +91,7 @@ async def test_main_flow(monkeypatch):
 
     monkeypatch.setattr(main, "load_instances", fake_load_instances)
     monkeypatch.setattr(main, "get_message_url", lambda m: "URL")
+
     async def fake_get_entity_name(v):
         return "name"
 


### PR DESCRIPTION
## Summary
- keep small utility tests in `test_main.py`
- add `test_config.py` for configuration helpers
- add `test_entities.py` for entity utilities
- add `test_folders.py` for folder helper logic
- add `test_main_flow.py` for main flow logic
- remove old test modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866ce970cc832ca7378d1cc3f1309c