### PR TITLE
Add common pytest fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,120 @@
 import sys
+from types import SimpleNamespace
 from pathlib import Path
+
+import pytest
 
 # Ensure project root is on sys.path for module imports
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.fixture
+def dummy_message_cls():
+    """Factory for creating simple dummy message objects."""
+
+    class DummyMessage:
+        def __init__(self, peer_id, msg_id: int = 123, text: str | None = None):
+            self.peer_id = peer_id
+            self.id = msg_id
+            self.raw_text = text
+            self.forwarded: list[int] = []
+
+        async def forward_to(self, target: int):
+            self.forwarded.append(target)
+
+    return DummyMessage
+
+
+@pytest.fixture
+def dummy_tg_client():
+    """Minimal stand-in for :class:`TelegramClient`."""
+
+    class DummyTG:
+        def __init__(self):
+            self.on_handler = None
+            self.sent = []
+            self.started = False
+
+        async def start(self):
+            self.started = True
+
+        def on(self, event):  # noqa: D401 - same interface as telethon
+            def deco(func):
+                self.on_handler = func
+                return func
+
+            return deco
+
+        async def send_message(self, *args, **kwargs):
+            self.sent.append((args, kwargs))
+
+        async def run_until_disconnected(self):
+            return None
+
+    return DummyTG()
+
+
+@pytest.fixture
+def dummy_client_for_list():
+    """Client used for ``list_folders`` tests."""
+
+    class DummyClientForList:
+        def __init__(self, filters):
+            self.connected = False
+            self.filters = filters
+            self.calls: list[str] = []
+
+        def is_connected(self):
+            return self.connected
+
+        async def connect(self):
+            self.connected = True
+            self.calls.append("connect")
+
+        async def __call__(self, req):
+            self.calls.append("request")
+            return SimpleNamespace(filters=self.filters)
+
+    return DummyClientForList
+
+
+@pytest.fixture
+def create_filter():
+    from telethon import types
+
+    def _create_filter():
+        return types.DialogFilter(
+            id=1, title=None, pinned_peers=[], include_peers=[], exclude_peers=[]
+        )
+
+    return _create_filter
+
+
+@pytest.fixture
+def dummy_folder_cls():
+    class DummyFolder:
+        def __init__(self, title):
+            self.title = title
+            self.include_peers = []
+
+    return DummyFolder
+
+
+@pytest.fixture
+def dummy_peer_cls():
+    class DummyPeer:
+        def __init__(self, cid):
+            self.channel_id = cid
+
+    return DummyPeer
+
+
+@pytest.fixture
+def dummy_folder_peers_cls(dummy_folder_cls, dummy_peer_cls):
+    class DummyFolderPeers(dummy_folder_cls):
+        def __init__(self, title, peers):
+            super().__init__(title)
+            self.include_peers = [dummy_peer_cls(cid) for cid in peers]
+
+    return DummyFolderPeers
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,21 +12,17 @@ def test_word_in_text_basic():
     assert main.word_in_text(words, "no match") is False
 
 
-class DummyMessage:
-    def __init__(self, peer_id):
-        self.peer_id = peer_id
-        self.id = 123
 
 
-def test_get_message_url_object_peer():
+def test_get_message_url_object_peer(dummy_message_cls):
     peer = SimpleNamespace(channel_id=42)
-    msg = DummyMessage(peer)
+    msg = dummy_message_cls(peer)
     assert main.get_message_url(msg) == "https://t.me/c/42/123"
 
 
-def test_get_message_url_dict_peer():
+def test_get_message_url_dict_peer(dummy_message_cls):
     peer = {"channel_id": 7}
-    msg = DummyMessage(peer)
+    msg = dummy_message_cls(peer)
     assert main.get_message_url(msg) == "https://t.me/c/7/123"
 
 


### PR DESCRIPTION
## Summary
- provide dummy factories/fixtures in `tests/conftest.py`
- rewrite folder, main, and main_flow tests to use common fixtures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886703295d8832c9c82c4cd52e21003