### PR TITLE
feat: collect additional chat ids

### DIFF
--- a/tests/test_folders.py
+++ b/tests/test_folders.py
@@ -17,8 +17,6 @@ async def test_list_folders_connect(monkeypatch, create_filter, dummy_client_for
     assert result == [f]
 
 
-
-
 @pytest.mark.asyncio
 async def test_get_folder_with_title_text(dummy_folder_cls):
     folders = [dummy_folder_cls(SimpleNamespace(text="MyFolder"))]
@@ -31,8 +29,6 @@ async def test_get_folder_not_found(dummy_folder_cls):
     folders = [dummy_folder_cls("Other")]
     result = await main.get_folder(folders, "Missing")
     assert result is None
-
-
 
 
 @pytest.mark.asyncio
@@ -61,7 +57,54 @@ async def test_update_instance_chat_ids(monkeypatch):
     monkeypatch.setattr(main, "get_folders_chat_ids", fake_get_folders_chat_ids)
     monkeypatch.setattr(main, "resolve_entities", fake_resolve_entities)
 
-    inst = main.Instance(name="i", words=[], target_chat=0, folders=["f"], chat_ids={4}, entities=["e"])
+    inst = main.Instance(
+        name="i", words=[], target_chat=0, folders=["f"], chat_ids={4}, entities=["e"]
+    )
 
     await main.update_instance_chat_ids(inst, True)
     assert inst.chat_ids == {4, 5, 6}
+
+
+@pytest.mark.asyncio
+async def test_get_folders_chat_ids_channel_with_topics(monkeypatch):
+    from telethon import functions, types
+
+    channel = types.InputPeerChannel(1, 2)
+    folder = SimpleNamespace(title="F1", include_peers=[channel])
+
+    async def fake_list_folders():
+        return [folder]
+
+    class DummyClient:
+        def __init__(self):
+            self.calls = []
+
+        async def __call__(self, req):
+            assert isinstance(req, functions.channels.GetForumTopicsRequest)
+            self.calls.append(True)
+            return SimpleNamespace(
+                topics=[SimpleNamespace(id=10), SimpleNamespace(id=11)]
+            )
+
+    monkeypatch.setattr(main, "list_folders", fake_list_folders)
+    monkeypatch.setattr(main, "client", DummyClient())
+
+    chat_ids = await main.get_folders_chat_ids(["F1"])
+    assert chat_ids == {1, 10, 11}
+
+
+@pytest.mark.asyncio
+async def test_get_folders_chat_ids_chat_and_user(monkeypatch):
+    from telethon import types
+
+    chat = types.InputPeerChat(7)
+    user = types.InputPeerUser(8, 1)
+    folder = SimpleNamespace(title="F2", include_peers=[chat, user])
+
+    async def fake_list_folders():
+        return [folder]
+
+    monkeypatch.setattr(main, "list_folders", fake_list_folders)
+
+    chat_ids = await main.get_folders_chat_ids(["F2"])
+    assert chat_ids == {7, 8}


### PR DESCRIPTION
## Summary
- detect more peer types when scanning folder chats
- query forum topics for channel peers
- expand folder chat id tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868bc0abac832c967ba827d6f80b32