### PR TITLE
Add target_entity forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install -r requirements.txt
 - `session` – path to your session file (default is `data/session`).
 - `log_level` – logging level (default is `info`).
 - `instances` – list of monitoring instances. Each instance may contain
-  `folders`, `chat_ids`, `entities`, `words` and `target_chat`.
+  `folders`, `chat_ids`, `entities`, `words`, `target_chat` and `target_entity`.
 
 ## Running
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -9,3 +9,4 @@ instances:
     folders: []
     words: ["my username"]
     target_chat: 0
+    target_entity: ""

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,8 @@ class Instance:
 
     name: str
     words: List[str]
-    target_chat: int
+    target_chat: int | None = None
+    target_entity: str | None = None
     folders: List[str] = field(default_factory=list)
     entities: List[str] = field(default_factory=list)
     chat_ids: Set[int] = field(default_factory=set)
@@ -219,6 +220,7 @@ async def load_instances(config: dict) -> List[Instance]:
                     "entities": config.get("entities", []),
                     "words": config.get("words", []),
                     "target_chat": config.get("target_chat"),
+                    "target_entity": config.get("target_entity"),
                 }
             ]
         }
@@ -232,6 +234,7 @@ async def load_instances(config: dict) -> List[Instance]:
             entities=inst_cfg.get("entities", []),
             words=inst_cfg.get("words", []),
             target_chat=inst_cfg.get("target_chat"),
+            target_entity=inst_cfg.get("target_entity"),
         )
         parsed_instances.append(instance)
     return parsed_instances
@@ -315,21 +318,28 @@ async def main() -> None:
                 continue
 
             chat_name = await get_entity_name(event.chat_id)
-            target_chat_name = await get_entity_name(inst.target_chat)
             if message.raw_text and word_in_text(inst.words, message.raw_text):
                 try:
                     url = get_message_url(message)
-                    await client.send_message(
-                        inst.target_chat, f"forwarded from: {url}"
-                    )
-                    await message.forward_to(inst.target_chat)
-                    logger.info(
-                        "Forwarded message %s from %s to %s for %s",
-                        message.id,
-                        chat_name,
-                        target_chat_name,
-                        inst.name,
-                    )
+                    destinations = []
+                    dest_names = []
+                    if inst.target_chat is not None:
+                        destinations.append(inst.target_chat)
+                        dest_names.append(await get_entity_name(inst.target_chat))
+                    if inst.target_entity:
+                        destinations.append(inst.target_entity)
+                        dest_names.append(await get_entity_name(inst.target_entity))
+
+                    for dest, dname in zip(destinations, dest_names):
+                        await client.send_message(dest, f"forwarded from: {url}")
+                        await message.forward_to(dest)
+                        logger.info(
+                            "Forwarded message %s from %s to %s for %s",
+                            message.id,
+                            chat_name,
+                            dname,
+                            inst.name,
+                        )
                 except Exception as exc:  # pylint: disable=broad-except
                     logger.error("Failed to forward message: %s", exc)
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import sys
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -19,7 +19,7 @@ def dummy_message_cls():
             self.raw_text = text
             self.forwarded: list[int] = []
 
-        async def forward_to(self, target: int):
+        async def forward_to(self, target):
             self.forwarded.append(target)
 
     return DummyMessage
@@ -117,4 +117,3 @@ def dummy_folder_peers_cls(dummy_folder_cls, dummy_peer_cls):
             self.include_peers = [dummy_peer_cls(cid) for cid in peers]
 
     return DummyFolderPeers
-

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,8 +12,6 @@ def test_word_in_text_basic():
     assert main.word_in_text(words, "no match") is False
 
 
-
-
 def test_get_message_url_object_peer(dummy_message_cls):
     peer = SimpleNamespace(channel_id=42)
     msg = dummy_message_cls(peer)
@@ -36,6 +34,7 @@ def test_load_instances_direct():
                 "entities": ["e"],
                 "words": ["w"],
                 "target_chat": 2,
+                "target_entity": "@test",
             }
         ]
     }
@@ -48,6 +47,7 @@ def test_load_instances_direct():
     assert inst.entities == ["e"]
     assert inst.words == ["w"]
     assert inst.target_chat == 2
+    assert inst.target_entity == "@test"
 
 
 def test_load_instances_backward_compat():
@@ -66,5 +66,4 @@ def test_load_instances_backward_compat():
     assert inst.entities == ["e"]
     assert inst.words == ["w"]
     assert inst.target_chat == 2
-
-
+    assert inst.target_entity is None

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -73,7 +73,9 @@ async def test_main_flow(monkeypatch, dummy_tg_client, dummy_message_cls):
     monkeypatch.setattr(main, "update_instance_chat_ids", fake_update)
 
     async def fake_load_instances(cfg):
-        return [main.Instance(name="i", words=["hi"], target_chat=99)]
+        return [
+            main.Instance(name="i", words=["hi"], target_chat=99, target_entity="name")
+        ]
 
     monkeypatch.setattr(main, "load_instances", fake_load_instances)
     monkeypatch.setattr(main, "get_message_url", lambda m: "URL")
@@ -90,5 +92,6 @@ async def test_main_flow(monkeypatch, dummy_tg_client, dummy_message_cls):
     msg = dummy_message_cls(SimpleNamespace(channel_id=1), msg_id=5, text="hi there")
     event = SimpleNamespace(message=msg, chat_id=1)
     await handler(event)
-    assert msg.forwarded == [99]
+    assert msg.forwarded == [99, "name"]
     assert dummy_client.sent[0][0][0] == 99
+    assert dummy_client.sent[1][0][0] == "name"


### PR DESCRIPTION
## Summary
- support forwarding to a new `target_entity`
- document the new option in README and config example
- test forwarding to both `target_chat` and `target_entity`

## Testing
- `pre-commit run --files src/main.py config-example.yml README.md tests/test_main.py tests/conftest.py tests/test_main_flow.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688736a73e8c832c9186306ee5604098