### PR TITLE
Add get_message_source function

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -109,10 +109,7 @@ async def list_folders():
 
 def get_message_url(message):
     """Return a t.me URL if the message has ``channel_id``."""
-    if isinstance(message.peer_id, dict):
-        chat_id = message.peer_id.get("channel_id")
-    else:
-        chat_id = getattr(message.peer_id, "channel_id", None)
+    chat_id = getattr(message.peer_id, "channel_id", None)
     msg_id = message.id
     url = f"https://t.me/c/{chat_id}/{msg_id}" if chat_id and msg_id else None
     return url
@@ -120,11 +117,7 @@ def get_message_url(message):
 
 def get_message_source(message):
     """Return URL of the message if available or a textual description."""
-    if isinstance(message.peer_id, dict):
-        channel_id = message.peer_id.get("channel_id")
-    else:
-        channel_id = getattr(message.peer_id, "channel_id", None)
-
+    channel_id = getattr(message.peer_id, "channel_id", None)
     url = get_message_url(message) if channel_id else None
     if url:
         return url
@@ -335,15 +328,6 @@ async def get_entity_name(peer_id, safe: bool = False) -> str:
             peer = types.PeerChat(pid)
         else:
             peer = types.PeerUser(pid)
-    elif isinstance(peer_id, dict):
-        if "channel_id" in peer_id:
-            peer = types.PeerChannel(peer_id["channel_id"])
-        elif "chat_id" in peer_id:
-            peer = types.PeerChat(peer_id["chat_id"])
-        elif "user_id" in peer_id:
-            peer = types.PeerUser(peer_id["user_id"])
-        else:
-            peer = peer_id
     else:
         peer = peer_id
 

--- a/src/main.py
+++ b/src/main.py
@@ -116,21 +116,21 @@ def get_message_url(message):
 
 
 def get_message_source(message):
-    """Return URL of the message if available or a textual description."""
+    """Return message URL when possible or a short textual source."""
     channel_id = getattr(message.peer_id, "channel_id", None)
-    url = get_message_url(message) if channel_id else None
-    if url:
-        return url
+    if channel_id:
+        url = get_message_url(message)
+        if url:
+            return url
 
-    username = None
-    if hasattr(message, "sender") and getattr(message.sender, "username", None):
-        username = f"@{message.sender.username}"
-
-    group_title = None
     if hasattr(message, "chat") and getattr(message.chat, "title", None):
-        group_title = message.chat.title
+        return f"group {message.chat.title}"
 
-    return f"private [{username}], group [{group_title}]"
+    username = getattr(getattr(message, "sender", None), "username", None)
+    if username:
+        return f"private @{username}"
+
+    return ""
 
 
 async def to_event_chat_id(peer) -> int | None:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -7,7 +7,7 @@ import src.main as main
 
 
 @pytest.mark.asyncio
-async def test_get_entity_name_with_cache_and_client(monkeypatch):
+async def test_get_chat_name_with_cache_and_client(monkeypatch):
     calls = []
 
     class DummyClient:
@@ -18,16 +18,16 @@ async def test_get_entity_name_with_cache_and_client(monkeypatch):
     main.client = DummyClient()
     main.entity_name_cache.clear()
 
-    name = await main.get_entity_name("id1")
+    name = await main.get_chat_name("id1", safe=True)
     assert name == "Chat_Name"
     # Second call should hit cache and not call client again
-    name2 = await main.get_entity_name("id1")
+    name2 = await main.get_chat_name("id1", safe=True)
     assert name2 == "Chat_Name"
     assert calls == ["id1"]
 
 
 @pytest.mark.asyncio
-async def test_get_entity_name_error(monkeypatch):
+async def test_get_chat_name_error(monkeypatch):
     class FailClient:
         async def get_entity(self, ident):
             raise RuntimeError("fail")
@@ -35,7 +35,7 @@ async def test_get_entity_name_error(monkeypatch):
     main.client = FailClient()
     main.entity_name_cache.clear()
 
-    name = await main.get_entity_name("https://t.me/testchat?param=1")
+    name = await main.get_chat_name("https://t.me/testchat?param=1", safe=True)
     assert name == "testchat"
 
 
@@ -48,32 +48,32 @@ async def test_get_entity_name_error(monkeypatch):
         (SimpleNamespace(id=42), "42"),
     ],
 )
-async def test_get_entity_name_various(monkeypatch, entity, expected):
+async def test_get_chat_name_various(monkeypatch, entity, expected):
     class DummyClient:
         async def get_entity(self, ident):
             return entity
 
     main.client = DummyClient()
     main.entity_name_cache.clear()
-    result = await main.get_entity_name("identifier")
+    result = await main.get_chat_name("identifier", safe=True)
     assert result == expected
 
 
 @pytest.mark.asyncio
-async def test_get_entity_name_empty_identifier(monkeypatch):
-    result = await main.get_entity_name("")
+async def test_get_chat_name_empty_identifier(monkeypatch):
+    result = await main.get_chat_name("", safe=True)
     assert result == "chat_history"
 
 
 @pytest.mark.asyncio
-async def test_get_entity_name_plus_link(monkeypatch):
+async def test_get_chat_name_plus_link(monkeypatch):
     class DummyClient:
         async def get_entity(self, ident):
             raise ValueError("not found")
 
     main.client = DummyClient()
     main.entity_name_cache.clear()
-    result = await main.get_entity_name("https://t.me/+abcDEF123")
+    result = await main.get_chat_name("https://t.me/+abcDEF123", safe=True)
     assert result == "invite_abcDEF123"
 
 
@@ -94,3 +94,22 @@ async def test_resolve_entities(monkeypatch):
     result = await main.resolve_entities(["1", "bad", "2", "1"])
     assert result == {1, 2}
     assert calls == ["1", "bad", "2", "1"]
+
+
+@pytest.mark.asyncio
+async def test_get_entity_name_from_int(monkeypatch):
+    recorded = []
+
+    class DummyClient:
+        async def get_entity(self, ident):
+            recorded.append(type(ident))
+            return SimpleNamespace(title="Chat")
+
+    main.client = DummyClient()
+    name = await main.get_entity_name(-1000000000042, safe=True)
+    assert name == "Chat"
+    assert recorded and issubclass(recorded[0], main.types.PeerChannel)
+
+
+def test_get_safe_name():
+    assert main.get_safe_name("A B") == "A_B"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,6 +24,20 @@ def test_get_message_url_dict_peer(dummy_message_cls):
     assert main.get_message_url(msg) == "https://t.me/c/7/123"
 
 
+def test_get_message_source_url(dummy_message_cls):
+    peer = {"channel_id": 8}
+    msg = dummy_message_cls(peer)
+    assert main.get_message_source(msg) == "https://t.me/c/8/123"
+
+
+def test_get_message_source_text(dummy_message_cls):
+    peer = {"chat_id": 9}
+    msg = dummy_message_cls(peer)
+    msg.sender = SimpleNamespace(username="user")
+    msg.chat = SimpleNamespace(title="Group")
+    assert main.get_message_source(msg) == "private [@user], group [Group]"
+
+
 def test_load_instances_direct():
     config = {
         "instances": [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,20 +18,20 @@ def test_get_message_url_object_peer(dummy_message_cls):
     assert main.get_message_url(msg) == "https://t.me/c/42/123"
 
 
-def test_get_message_url_dict_peer(dummy_message_cls):
-    peer = {"channel_id": 7}
+def test_get_message_url_peerchannel(dummy_message_cls):
+    peer = main.types.PeerChannel(7)
     msg = dummy_message_cls(peer)
     assert main.get_message_url(msg) == "https://t.me/c/7/123"
 
 
 def test_get_message_source_url(dummy_message_cls):
-    peer = {"channel_id": 8}
+    peer = main.types.PeerChannel(8)
     msg = dummy_message_cls(peer)
     assert main.get_message_source(msg) == "https://t.me/c/8/123"
 
 
 def test_get_message_source_text(dummy_message_cls):
-    peer = {"chat_id": 9}
+    peer = SimpleNamespace(chat_id=9)
     msg = dummy_message_cls(peer)
     msg.sender = SimpleNamespace(username="user")
     msg.chat = SimpleNamespace(title="Group")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,7 +35,14 @@ def test_get_message_source_text(dummy_message_cls):
     msg = dummy_message_cls(peer)
     msg.sender = SimpleNamespace(username="user")
     msg.chat = SimpleNamespace(title="Group")
-    assert main.get_message_source(msg) == "private [@user], group [Group]"
+    assert main.get_message_source(msg) == "group Group"
+
+
+def test_get_message_source_private(dummy_message_cls):
+    peer = SimpleNamespace(chat_id=10)
+    msg = dummy_message_cls(peer)
+    msg.sender = SimpleNamespace(username="user")
+    assert main.get_message_source(msg) == "private @user"
 
 
 def test_load_instances_direct():

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -78,7 +78,11 @@ async def test_main_flow(monkeypatch, dummy_tg_client, dummy_message_cls):
         ]
 
     monkeypatch.setattr(main, "load_instances", fake_load_instances)
-    monkeypatch.setattr(main, "get_message_source", lambda m: "URL")
+
+    async def fake_get_message_source(m):
+        return "URL"
+
+    monkeypatch.setattr(main, "get_message_source", fake_get_message_source)
 
     async def fake_get_chat_name(v, safe=False):
         return "name"

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -80,10 +80,10 @@ async def test_main_flow(monkeypatch, dummy_tg_client, dummy_message_cls):
     monkeypatch.setattr(main, "load_instances", fake_load_instances)
     monkeypatch.setattr(main, "get_message_source", lambda m: "URL")
 
-    async def fake_get_entity_name(v):
+    async def fake_get_chat_name(v, safe=False):
         return "name"
 
-    monkeypatch.setattr(main, "get_entity_name", fake_get_entity_name)
+    monkeypatch.setattr(main, "get_chat_name", fake_get_chat_name)
 
     await main.main()
     assert main.config is config

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -78,7 +78,7 @@ async def test_main_flow(monkeypatch, dummy_tg_client, dummy_message_cls):
         ]
 
     monkeypatch.setattr(main, "load_instances", fake_load_instances)
-    monkeypatch.setattr(main, "get_message_url", lambda m: "URL")
+    monkeypatch.setattr(main, "get_message_source", lambda m: "URL")
 
     async def fake_get_entity_name(v):
         return "name"


### PR DESCRIPTION
## Summary
- add `get_message_source` to describe message origin
- use it when forwarding messages
- log URL of forwarded message
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68874e39eaac832c819080af92e3eb83