### PR TITLE
Implement message stats tracking

### DIFF
--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,19 @@
+import json
+import src.main as main
+
+
+def test_stats_increment_and_flush(tmp_path):
+    path = tmp_path / "stats.json"
+    tracker = main.StatsTracker(str(path), flush_interval=0)
+    tracker.increment("a")
+    tracker.increment("a")
+    tracker.increment("b")
+    tracker.flush()
+    data = json.loads(path.read_text())
+    assert data["total"] == 3
+    inst_a = next(i for i in data["instances"] if i["name"] == "a")
+    inst_b = next(i for i in data["instances"] if i["name"] == "b")
+    assert inst_a["total"] == 2
+    assert inst_b["total"] == 1
+    day = list(inst_a["days"].keys())[0]
+    assert inst_a["days"][day] == 2


### PR DESCRIPTION
## Summary
- handle new messages in a dedicated `process_message` function
- track processed message count with a `StatsTracker`
- flush stats to `data/stats.json` every minute
- test statistics handling and integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68888269a7e0832c86fc880e9cff73d7