### PR TITLE
Improve prompt evaluation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ from typing import List, Set
 
 import yaml
 from openai import OpenAI
+import httpx
 from pydantic import BaseModel
 from telethon import TelegramClient, events, functions, types
 from telethon.utils import get_peer_id, resolve_id
@@ -69,19 +70,21 @@ class StatsTracker:
         self.flush_interval = flush_interval
         self.last_flush = time.monotonic()
         self.dirty = False
-        self.data = {"total": 0, "instances": []}
+        self.data = {"total": 0, "tokens": 0, "instances": []}
         if os.path.exists(path):
             try:
                 with open(path, "r", encoding="utf-8") as f:
                     self.data = json.load(f)
             except Exception:  # pragma: no cover - corrupt file
-                self.data = {"total": 0, "instances": []}
+                self.data = {"total": 0, "tokens": 0, "instances": []}
+        self.data.setdefault("tokens", 0)
 
     def _get_inst(self, name: str) -> dict:
         for inst in self.data.get("instances", []):
             if inst.get("name") == name:
+                inst.setdefault("tokens", 0)
                 return inst
-        inst = {"name": name, "total": 0, "days": {}}
+        inst = {"name": name, "total": 0, "tokens": 0, "days": {}}
         self.data.setdefault("instances", []).append(inst)
         return inst
 
@@ -91,6 +94,16 @@ class StatsTracker:
         inst["total"] = inst.get("total", 0) + 1
         day = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d")
         inst["days"][day] = inst["days"].get(day, 0) + 1
+        self.dirty = True
+        if time.monotonic() - self.last_flush >= self.flush_interval:
+            self.flush()
+
+    def add_tokens(self, name: str, tokens: int) -> None:
+        if tokens <= 0:
+            return
+        inst = self._get_inst(name)
+        self.data["tokens"] = self.data.get("tokens", 0) + tokens
+        inst["tokens"] = inst.get("tokens", 0) + tokens
         self.dirty = True
         if time.monotonic() - self.last_flush >= self.flush_interval:
             self.flush()
@@ -136,7 +149,9 @@ def word_in_text(words: List[str], text: str) -> bool:
     return any(word.lower() in text_lower for word in words)
 
 
-async def match_prompts(prompts: List[str], text: str, threshold: int) -> int:
+async def match_prompts(
+    prompts: List[str], text: str, threshold: int, inst_name: str | None = None
+) -> int:
     """Return similarity score from 0 to 5 for ``text`` using OpenAI."""
     if not prompts or not config.get("openai_api_key"):
         return 0
@@ -144,7 +159,9 @@ async def match_prompts(prompts: List[str], text: str, threshold: int) -> int:
     class EvaluateResult(BaseModel):
         similarity: int
 
-    client = OpenAI(api_key=config["openai_api_key"])
+    proxy = config.get("proxy_url")
+    http_client = httpx.Client(proxies=proxy) if proxy else None
+    client = OpenAI(api_key=config["openai_api_key"], http_client=http_client)
     model = config.get("openai_model", "gpt-4.1-mini")
 
     best = 0
@@ -167,10 +184,12 @@ async def match_prompts(prompts: List[str], text: str, threshold: int) -> int:
                 response_format=EvaluateResult,
             )
             similarity = completion.choices[0].message.parsed.similarity
+            tokens = getattr(getattr(completion, "usage", None), "total_tokens", 0)
+            if inst_name:
+                stats.add_tokens(inst_name, tokens)
         except Exception as exc:  # pragma: no cover - external call
             logger.error("Failed to query OpenAI: %s", exc)
             similarity = 0
-        logger.debug("Prompt check: %s -> %s", prompt, similarity)
         best = max(best, similarity)
         if similarity >= threshold:
             return similarity
@@ -526,9 +545,8 @@ async def process_message(inst: Instance, event: events.NewMessage.Event) -> Non
             forward = True
         elif inst.prompts:
             score = await match_prompts(
-                inst.prompts, message.raw_text, inst.prompt_threshold
+                inst.prompts, message.raw_text, inst.prompt_threshold, inst.name
             )
-            logger.debug("Prompt score %s for %s", score, inst.name)
             if score >= inst.prompt_threshold:
                 forward = True
     if forward:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -136,8 +136,8 @@ async def test_match_prompts_iter(monkeypatch):
     calls = []
 
     class DummyCompletions:
-        def parse(self, *, model, messages, response_model):  # noqa: D401 - test stub
-            prompt = messages[0]["content"]
+        def parse(self, *, model=None, messages=None, response_format=None, response_model=None):  # noqa: D401 - test stub
+            prompt = messages[0]["content"].split("\n", 1)[0]
             calls.append(prompt)
             score = {"p1": 3, "p2": 5}[prompt]
             return SimpleNamespace(
@@ -151,14 +151,12 @@ async def test_match_prompts_iter(monkeypatch):
             )
 
     class DummyClient:
-        def __init__(self, api_key=None):  # noqa: D401 - test stub
+        def __init__(self, api_key=None, http_client=None):  # noqa: D401 - test stub
             self.chat = SimpleNamespace(completions=DummyCompletions())
 
-    import openai
-
-    monkeypatch.setattr(openai, "OpenAI", DummyClient)
+    monkeypatch.setattr(main, "OpenAI", DummyClient)
     main.config["openai_api_key"] = "k"
-    result = await main.match_prompts(["p1", "p2"], "msg", 4)
+    result = await main.match_prompts(["p1", "p2"], "msg", 4, "i")
     assert result == 5
     assert calls == ["p1", "p2"]
 
@@ -168,8 +166,8 @@ async def test_match_prompts_iter_stop(monkeypatch):
     calls = []
 
     class DummyCompletions:
-        def parse(self, *, model, messages, response_model):  # noqa: D401 - test stub
-            prompt = messages[0]["content"]
+        def parse(self, *, model=None, messages=None, response_format=None, response_model=None):  # noqa: D401 - test stub
+            prompt = messages[0]["content"].split("\n", 1)[0]
             calls.append(prompt)
             score = {"p1": 5, "p2": 0}[prompt]
             return SimpleNamespace(
@@ -183,13 +181,11 @@ async def test_match_prompts_iter_stop(monkeypatch):
             )
 
     class DummyClient:
-        def __init__(self, api_key=None):  # noqa: D401 - test stub
+        def __init__(self, api_key=None, http_client=None):  # noqa: D401 - test stub
             self.chat = SimpleNamespace(completions=DummyCompletions())
 
-    import openai
-
-    monkeypatch.setattr(openai, "OpenAI", DummyClient)
+    monkeypatch.setattr(main, "OpenAI", DummyClient)
     main.config["openai_api_key"] = "k"
-    result = await main.match_prompts(["p1", "p2"], "msg", 4)
+    result = await main.match_prompts(["p1", "p2"], "msg", 4, "i")
     assert result == 5
     assert calls == ["p1"]

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -131,8 +131,9 @@ async def test_process_message_prompt(monkeypatch, dummy_message_cls, tmp_path):
         target_chat=1,
     )
 
-    async def fake_match(prompts, text, threshold):
+    async def fake_match(prompts, text, threshold, inst_name):
         assert threshold == 4
+        assert inst_name == "p"
         return 5
 
     async def fake_get_message_source(msg):

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -9,12 +9,17 @@ def test_stats_increment_and_flush(tmp_path):
     tracker.increment("a")
     tracker.increment("a")
     tracker.increment("b")
+    tracker.add_tokens("a", 10)
+    tracker.add_tokens("b", 5)
     tracker.flush()
     data = json.loads(path.read_text())
     assert data["total"] == 3
+    assert data["tokens"] == 15
     inst_a = next(i for i in data["instances"] if i["name"] == "a")
     inst_b = next(i for i in data["instances"] if i["name"] == "b")
     assert inst_a["total"] == 2
     assert inst_b["total"] == 1
+    assert inst_a["tokens"] == 10
+    assert inst_b["tokens"] == 5
     day = list(inst_a["days"].keys())[0]
     assert inst_a["days"][day] == 2


### PR DESCRIPTION
## Summary
- support tracking token usage in `StatsTracker`
- add optional proxy parameter when calling OpenAI
- record tokens used by `match_prompts`
- remove noisy debug about prompt score
- update tests to mock OpenAI calls

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888fd364848832cb90d4efbfcd89bc5