### PR TITLE
Add fragment citation in EvaluateResult

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -139,13 +139,24 @@ async def test_match_prompt(monkeypatch):
     calls = []
 
     class DummyCompletions:
-        def parse(self, *, model=None, messages=None, response_format=None, response_model=None):  # noqa: D401 - test stub
+        def parse(
+            self,
+            *,
+            model=None,
+            messages=None,
+            response_format=None,
+            response_model=None,
+        ):
             prompt = messages[0]["content"].split("\n", 1)[0]
             calls.append(prompt)
             return SimpleNamespace(
                 choices=[
                     SimpleNamespace(
-                        message=SimpleNamespace(parsed=SimpleNamespace(similarity=3))
+                        message=SimpleNamespace(
+                            parsed=main.EvaluateResult(
+                                similarity=3, main_fragment="frag"
+                            )
+                        )
                     )
                 ]
             )
@@ -158,7 +169,9 @@ async def test_match_prompt(monkeypatch):
     main.config["openai_api_key"] = "k"
     prompt = main.Prompt(name="p1", prompt="p1", threshold=2)
     result = await main.match_prompt(prompt, "msg", "i")
-    assert result == 3
+    assert isinstance(result, main.EvaluateResult)
+    assert result.similarity == 3
+    assert result.main_fragment == "frag"
     assert calls == ["p1"]
 
 
@@ -167,7 +180,8 @@ async def test_match_prompt_no_api(monkeypatch):
     main.config["openai_api_key"] = ""
     prompt = main.Prompt(name="n", prompt="hello")
     result = await main.match_prompt(prompt, "msg")
-    assert result == 0
+    assert isinstance(result, main.EvaluateResult)
+    assert result.similarity == 0
 
 
 def test_get_forward_reason_text_word():
@@ -177,6 +191,14 @@ def test_get_forward_reason_text_word():
 def test_get_forward_reason_text_prompt():
     p = main.Prompt(name="n", prompt="p", threshold=4)
     assert main.get_forward_reason_text(prompt=p, score=4) == "n: 4/5"
+
+
+def test_get_forward_reason_text_fragment():
+    p = main.Prompt(name="n", prompt="p", threshold=4)
+    assert (
+        main.get_forward_reason_text(prompt=p, score=4, fragment="frag")
+        == "n: 4/5 - frag"
+    )
 
 
 @pytest.mark.asyncio
@@ -189,6 +211,9 @@ async def test_get_forward_message_text(monkeypatch, dummy_message_cls):
 
     monkeypatch.setattr(main, "get_message_source", fake_get_message_source)
     text = await main.get_forward_message_text(
-        msg, prompt=main.Prompt(name="n", prompt="p"), score=4
+        msg,
+        prompt=main.Prompt(name="n", prompt="p"),
+        score=4,
+        fragment="frag",
     )
-    assert text == "n: 4/5\nsrc"
+    assert text == "n: 4/5 - frag\nsrc"

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -133,7 +133,7 @@ async def test_process_message_prompt(monkeypatch, dummy_message_cls, tmp_path):
     async def fake_match(prompt, text, inst_name):
         assert prompt.prompt == "hi"
         assert inst_name == "p"
-        return 5
+        return main.EvaluateResult(similarity=5, main_fragment="frag")
 
     async def fake_get_message_source(msg):
         return "src"


### PR DESCRIPTION
## Summary
- extend `EvaluateResult` with `main_fragment`
- include fragment request in OpenAI prompt
- show fragment in forwarding reason text
- adjust processing flow and tests for new structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68892567aa74832ca628789cf4a2ba36