### PR TITLE
Add ignore_usernames config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pip install -r requirements.txt
 - `api_hash` – your Telegram API hash.
 - `session` – path to your session file (default is `data/session`).
 - `log_level` – logging level (default is `info`).
+- `ignore_usernames` – list of usernames to ignore when processing messages.
 - `instances` – list of monitoring instances. Each instance may contain
   `folders`, `chat_ids`, `entities`, `words`, `target_chat`,
   `target_entity` and `folder_mute`.

--- a/config-example.yml
+++ b/config-example.yml
@@ -4,6 +4,7 @@ session: data/session
 log_level: info
 openai_api_key: ""
 openai_model: gpt-4.1-mini
+ignore_usernames: []
 instances:
   - name: default
     entities:

--- a/src/main.py
+++ b/src/main.py
@@ -295,7 +295,11 @@ def get_forward_reason_text(
 
 
 async def get_forward_message_text(
-    message, *, prompt: Prompt | None = None, score: int | None = None, word: str | None = None
+    message,
+    *,
+    prompt: Prompt | None = None,
+    score: int | None = None,
+    word: str | None = None,
 ) -> str:
     """Return text to send before forwarding ``message``."""
     reason = get_forward_reason_text(prompt=prompt, score=score, word=word)
@@ -661,6 +665,13 @@ async def main() -> None:
 
     @client.on(events.NewMessage)
     async def handler(event: events.NewMessage.Event) -> None:
+        username = getattr(getattr(event.message, "sender", None), "username", None)
+        if username and username.lower() in [
+            u.lower() for u in config.get("ignore_usernames", [])
+        ]:
+            logger.debug("Ignoring message from @%s", username)
+            return
+
         for inst in instances:
             if event.chat_id in inst.chat_ids:
                 await process_message(inst, event)

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -151,3 +151,56 @@ async def test_process_message_prompt(monkeypatch, dummy_message_cls, tmp_path):
 
     assert sent[0][0][0] == 1
     assert msg.forwarded == [1]
+
+
+@pytest.mark.asyncio
+async def test_ignore_usernames(
+    monkeypatch, dummy_tg_client, dummy_message_cls, tmp_path
+):
+    config = {"log_level": "info", "ignore_usernames": ["bad"]}
+    monkeypatch.setattr(main, "load_config", lambda: config)
+    monkeypatch.setattr(main, "get_api_credentials", lambda cfg: (1, "h", "s"))
+
+    dummy_client = dummy_tg_client
+    monkeypatch.setattr(main, "TelegramClient", lambda s, a, b: dummy_client)
+
+    stats_path = tmp_path / "stats.json"
+    monkeypatch.setattr(
+        main, "stats", main.StatsTracker(str(stats_path), flush_interval=0)
+    )
+
+    async def fake_rescan(inst):
+        return None
+
+    monkeypatch.setattr(main, "rescan_loop", fake_rescan)
+
+    async def fake_update(inst, fr):
+        inst.chat_ids = {1}
+
+    monkeypatch.setattr(main, "update_instance_chat_ids", fake_update)
+
+    async def fake_load_instances(cfg):
+        return [main.Instance(name="i", words=["hi"], target_chat=99)]
+
+    monkeypatch.setattr(main, "load_instances", fake_load_instances)
+
+    async def fake_get_message_source(m):
+        return "URL"
+
+    monkeypatch.setattr(main, "get_message_source", fake_get_message_source)
+
+    async def fake_get_chat_name(v, safe=False):
+        return "name"
+
+    monkeypatch.setattr(main, "get_chat_name", fake_get_chat_name)
+
+    await main.main()
+
+    handler = dummy_client.on_handler
+    msg = dummy_message_cls(SimpleNamespace(channel_id=1), msg_id=5, text="hi")
+    msg.sender = SimpleNamespace(username="bad")
+    event = SimpleNamespace(message=msg, chat_id=1)
+    await handler(event)
+    assert msg.forwarded == []
+    assert dummy_client.sent == []
+    assert main.stats.data["total"] == 0


### PR DESCRIPTION
## Summary
- add `ignore_usernames` to config and docs
- skip processing messages from ignored usernames
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688925b134d4832c894857a0a12a0418