### PR TITLE
Fix tests for new prompt result

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -158,7 +158,7 @@ async def test_match_prompt(monkeypatch):
     main.config["openai_api_key"] = "k"
     prompt = main.Prompt(name="p1", prompt="p1", threshold=2)
     result = await main.match_prompt(prompt, "msg", "i")
-    assert result == 3
+    assert result.similarity == 3
     assert calls == ["p1"]
 
 
@@ -167,7 +167,7 @@ async def test_match_prompt_no_api(monkeypatch):
     main.config["openai_api_key"] = ""
     prompt = main.Prompt(name="n", prompt="hello")
     result = await main.match_prompt(prompt, "msg")
-    assert result == 0
+    assert result == main.EvaluateResult(similarity=0, main_fragment="")
 
 
 def test_get_forward_reason_text_word():

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -133,7 +133,7 @@ async def test_process_message_prompt(monkeypatch, dummy_message_cls, tmp_path):
     async def fake_match(prompt, text, inst_name):
         assert prompt.prompt == "hi"
         assert inst_name == "p"
-        return 5
+        return main.EvaluateResult(similarity=5, main_fragment="")
 
     async def fake_get_message_source(msg):
         return "src"


### PR DESCRIPTION
## Summary
- update tests for EvaluateResult return type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688931480eb0832ca249c94d32997c00