### PR TITLE
Add ignore_words feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install -r requirements.txt
 - `log_level` – logging level (default is `info`).
 - `ignore_usernames` – list of usernames to ignore when processing messages.
 - `instances` – list of monitoring instances. Each instance may contain
-  `folders`, `chat_ids`, `entities`, `words`, `target_chat`,
+  `folders`, `chat_ids`, `entities`, `words`, `ignore_words`, `target_chat`,
   `target_entity` and `folder_mute`.
 
 ## Running

--- a/config-example.yml
+++ b/config-example.yml
@@ -12,6 +12,7 @@ instances:
     folders: []
     folder_mute: false
     words: ["my username"]
+    ignore_words: []
     prompts:
       - name: example
         prompt: Сообщение содержит недовольство.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -75,9 +75,7 @@ def test_load_instances_direct():
                 "chat_ids": [1],
                 "entities": ["e"],
                 "words": ["w"],
-                "prompts": [
-                    {"name": "p", "prompt": "p", "threshold": 3}
-                ],
+                "prompts": [{"name": "p", "prompt": "p", "threshold": 3}],
                 "target_chat": 2,
                 "target_entity": "@test",
             }
@@ -134,12 +132,31 @@ def test_load_instances_folder_mute():
     assert instances[0].folder_mute is True
 
 
+def test_load_instances_ignore_words():
+    config = {"instances": [{"name": "i", "words": [], "ignore_words": ["bad"]}]}
+    instances = asyncio.run(main.load_instances(config))
+    assert instances[0].ignore_words == ["bad"]
+
+
+def test_load_instances_ignore_words_backward():
+    config = {"words": [], "ignore_words": ["bad"]}
+    instances = asyncio.run(main.load_instances(config))
+    assert instances[0].ignore_words == ["bad"]
+
+
 @pytest.mark.asyncio
 async def test_match_prompt(monkeypatch):
     calls = []
 
     class DummyCompletions:
-        def parse(self, *, model=None, messages=None, response_format=None, response_model=None):  # noqa: D401 - test stub
+        def parse(
+            self,
+            *,
+            model=None,
+            messages=None,
+            response_format=None,
+            response_model=None,
+        ):  # noqa: D401 - test stub
             prompt = messages[0]["content"].split("\n", 1)[0]
             calls.append(prompt)
             return SimpleNamespace(


### PR DESCRIPTION
## Summary
- support optional `ignore_words` per instance
- skip messages containing ignored words
- document `ignore_words` in README and example config
- test instance loading and main flow with ignored words

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68894278a320832cb991b53ce3a578ff