### PR TITLE
Improve forwarded message formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ matching messages to a target chat.
 - Listen folders, chats, channels
 - Multiple instances for different chats, words and targets
 - Each instance has target chat
+- Forwarded messages include a link to the original message
 
 ## Setup
 

--- a/src/telegram_utils.py
+++ b/src/telegram_utils.py
@@ -126,7 +126,7 @@ def get_forward_reason_text(
         name = getattr(prompt, "name", None) or "prompt"
         reason = f"{name}: {score}/5"
         if fragment:
-            reason += f" - {fragment}"
+            reason += f" - `{fragment}`"
         return reason
     return ""
 

--- a/src/telegram_utils.py
+++ b/src/telegram_utils.py
@@ -99,11 +99,16 @@ async def get_message_source(message):
             name = f"@{chat_username}"
 
     if chat_type == "private":
-        result = f"Forwarded from: {chat_type} {name}"
+        base_name = f"{chat_type} {name}"
     else:
-        result = f"Forwarded from: {name}"
-    if url:
-        result += f" - {url}"
+        base_name = name
+
+    if url and chat_type != "private":
+        result = f"Forwarded from: [{base_name}]({url})"
+    else:
+        result = f"Forwarded from: {base_name}"
+        if url:
+            result += f" - {url}"
     return result
 
 
@@ -140,7 +145,7 @@ async def get_forward_message_text(
     )
     source = await get_message_source(message)
     if reason:
-        return f"{reason}\n{source}"
+        return f"{reason}\n\n{source}"
     return source
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,7 +38,7 @@ async def test_get_message_source_url(monkeypatch, dummy_message_cls):
 
     monkeypatch.setattr(tgu, "get_chat_name", fake_get_chat_name)
     res = await tgu.get_message_source(msg)
-    assert res == "Forwarded from: @chan - https://t.me/c/8/123"
+    assert res == "Forwarded from: [@chan](https://t.me/c/8/123)"
 
 
 @pytest.mark.asyncio
@@ -211,4 +211,4 @@ async def test_get_forward_message_text(monkeypatch, dummy_message_cls):
     text = await tgu.get_forward_message_text(
         msg, prompt=prompts.Prompt(name="n", prompt="p"), score=4
     )
-    assert text == "n: 4/5\nsrc"
+    assert text == "n: 4/5\n\nsrc"


### PR DESCRIPTION
## Summary
- show a Markdown link to the original post in forwarded message prefix
- insert an extra newline before the prefix
- document the updated behaviour
- update tests for new formatting

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889e6660820832c8a6607204adfd411