### PR TITLE
Add false positive reaction forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install -r requirements.txt
 - `ignore_usernames` – list of usernames to ignore when processing messages.
 - `instances` – list of monitoring instances. Each instance may contain
   `folders`, `chat_ids`, `entities`, `words`, `ignore_words`, `target_chat`,
-  `target_entity` and `folder_mute`.
+  `target_entity`, `folder_mute` and `false_positive_entity`.
 
 ## Running
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -19,3 +19,4 @@ instances:
         threshold: 4
     target_chat: 0
     target_entity: ""
+    false_positive_entity: ""

--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from typing import List
 
-from telethon import TelegramClient, events
+from telethon import TelegramClient, events, types
 
 from . import prompts, telegram_utils
 from .config import Instance, get_api_credentials, load_config, load_instances
@@ -28,6 +28,8 @@ instances: List[Instance] = []
 
 # Use shared stats tracker
 stats = global_stats
+
+NEGATIVE_REACTIONS = {"\U0001F44E"}  # thumbs down
 
 
 def setup_logging(level: str = "info") -> None:
@@ -143,6 +145,47 @@ async def process_message(inst: Instance, event: events.NewMessage.Event) -> Non
         )
 
 
+async def handle_reaction(update: "types.UpdateMessageReactions") -> None:
+    """Forward negatively reacted messages to false_positive_entity."""
+
+    if not update or not hasattr(update, "reactions"):
+        return
+
+    emojis: list[str] = []
+    for rc in getattr(update.reactions, "results", []):
+        reaction = getattr(rc, "reaction", None)
+        if isinstance(reaction, types.ReactionEmoji):
+            emojis.append(reaction.emoticon)
+
+    if not any(e in NEGATIVE_REACTIONS for e in emojis):
+        return
+
+    peer_id = await telegram_utils.to_event_chat_id(update.peer)
+    for inst in instances:
+        if not inst.false_positive_entity or not inst.target_entity:
+            continue
+        target_id = await telegram_utils.to_event_chat_id(inst.target_entity)
+        if peer_id != target_id:
+            continue
+
+        message = await client.get_messages(update.peer, ids=update.msg_id)
+        if not message:
+            return
+        text = await get_forward_message_text(message)
+        await client.send_message(inst.false_positive_entity, text)
+        forwarded = await message.forward_to(inst.false_positive_entity)
+        f_url = get_message_url(forwarded) if forwarded else None
+        logger.info(
+            "Forwarded message %s from %s to %s for %s (target url: %s)",
+            message.id,
+            inst.target_entity,
+            inst.false_positive_entity,
+            inst.name,
+            f_url,
+        )
+        break
+
+
 async def main() -> None:
     global client, instances, config
     config = load_config()
@@ -162,6 +205,10 @@ async def main() -> None:
     for inst in instances:
         await update_instance_chat_ids(inst, True)
         asyncio.create_task(rescan_loop(inst))
+
+    @client.on(events.Raw(types.UpdateMessageReactions))
+    async def reaction_event_handler(update) -> None:
+        await handle_reaction(update)
 
     @client.on(events.NewMessage)
     async def handler(event: events.NewMessage.Event) -> None:

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,7 @@ class Instance:
     ignore_words: List[str] = field(default_factory=list)
     target_chat: int | None = None
     target_entity: str | None = None
+    false_positive_entity: str | None = None
     folders: List[str] = field(default_factory=list)
     entities: List[str] = field(default_factory=list)
     chat_ids: Set[int] = field(default_factory=set)
@@ -59,6 +60,7 @@ async def load_instances(config: dict) -> List[Instance]:
                     "ignore_words": config.get("ignore_words", []),
                     "target_chat": config.get("target_chat"),
                     "target_entity": config.get("target_entity"),
+                    "false_positive_entity": config.get("false_positive_entity"),
                 }
             ]
         }
@@ -88,6 +90,7 @@ async def load_instances(config: dict) -> List[Instance]:
             ignore_words=inst_cfg.get("ignore_words", []),
             target_chat=inst_cfg.get("target_chat"),
             target_entity=inst_cfg.get("target_entity"),
+            false_positive_entity=inst_cfg.get("false_positive_entity"),
             folder_mute=inst_cfg.get("folder_mute", False),
             prompts=parsed_prompts,
         )

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -213,6 +213,51 @@ async def test_ignore_usernames(
 
 
 @pytest.mark.asyncio
+async def test_false_positive_reaction(monkeypatch, dummy_message_cls):
+    sent = []
+
+    class DummyClient:
+        async def send_message(self, *args, **kwargs):
+            sent.append((args, kwargs))
+
+        async def get_messages(self, peer, ids):
+            return msg
+
+    app.client = DummyClient()
+    inst = app.Instance(
+        name="i",
+        words=[],
+        target_entity="t",
+        false_positive_entity="fp",
+    )
+    app.instances = [inst]
+
+    msg = dummy_message_cls(SimpleNamespace(channel_id=77), msg_id=5, text="hi")
+
+    update = tgu.types.UpdateMessageReactions(
+        peer=tgu.types.PeerChannel(77),
+        msg_id=5,
+        reactions=tgu.types.MessageReactions(
+            results=[tgu.types.ReactionCount(tgu.types.ReactionEmoji("\U0001F44E"), 1)]
+        ),
+    )
+
+    async def fake_to_event_chat_id(peer):
+        return 77
+
+    async def fake_get_forward_message_text(m, **kwargs):
+        return "src"
+
+    monkeypatch.setattr(tgu, "to_event_chat_id", fake_to_event_chat_id)
+    monkeypatch.setattr(tgu, "get_forward_message_text", fake_get_forward_message_text)
+
+    await app.handle_reaction(update)
+
+    assert sent[0][0][0] == "fp"
+    assert msg.forwarded == ["fp"]
+
+
+@pytest.mark.asyncio
 async def test_ignore_words(monkeypatch, dummy_tg_client, dummy_message_cls, tmp_path):
     config = {"log_level": "info"}
     monkeypatch.setattr(app, "load_config", lambda: config)


### PR DESCRIPTION
## Summary
- add `false_positive_entity` setting
- forward negatively reacted messages to `false_positive_entity`
- document new config option
- test negative reaction forwarding

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a513394f4832c8f69f7b54066f9fd