### PR TITLE
Add true_positive_entity and entity caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install -r requirements.txt
 - `ignore_usernames` – list of usernames to ignore when processing messages.
 - `instances` – list of monitoring instances. Each instance may contain
   `folders`, `chat_ids`, `entities`, `words`, `ignore_words`, `target_chat`,
-  `target_entity`, `folder_mute` and `false_positive_entity`.
+  `target_entity`, `folder_mute`, `false_positive_entity` and `true_positive_entity`.
 
 ## Running
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -20,3 +20,4 @@ instances:
     target_chat: 0
     target_entity: ""
     false_positive_entity: ""
+    true_positive_entity: ""

--- a/src/config.py
+++ b/src/config.py
@@ -19,6 +19,7 @@ class Instance:
     target_chat: int | None = None
     target_entity: str | None = None
     false_positive_entity: str | None = None
+    true_positive_entity: str | None = None
     folders: List[str] = field(default_factory=list)
     entities: List[str] = field(default_factory=list)
     chat_ids: Set[int] = field(default_factory=set)
@@ -61,6 +62,7 @@ async def load_instances(config: dict) -> List[Instance]:
                     "target_chat": config.get("target_chat"),
                     "target_entity": config.get("target_entity"),
                     "false_positive_entity": config.get("false_positive_entity"),
+                    "true_positive_entity": config.get("true_positive_entity"),
                 }
             ]
         }
@@ -91,6 +93,7 @@ async def load_instances(config: dict) -> List[Instance]:
             target_chat=inst_cfg.get("target_chat"),
             target_entity=inst_cfg.get("target_entity"),
             false_positive_entity=inst_cfg.get("false_positive_entity"),
+            true_positive_entity=inst_cfg.get("true_positive_entity"),
             folder_mute=inst_cfg.get("folder_mute", False),
             prompts=parsed_prompts,
         )


### PR DESCRIPTION
## Summary
- support a new `true_positive_entity` config option
- cache `get_entity` results in memory
- forward messages to a configured chat for positive reactions
- document the new option
- test entity caching and positive reaction forwarding

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a67e5a5e4832ca4de571c719f0f40