### PR TITLE
Add Langfuse tracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ pip install -r requirements.txt
 - `api_hash` – your Telegram API hash.
 - `session` – path to your session file (default is `data/session`).
 - `log_level` – logging level (default is `info`).
+- `langfuse_public_key` – (optional) public key to enable Langfuse tracing.
+- `langfuse_secret_key` – (optional) secret key for Langfuse.
+- `langfuse_base_url` – (optional) custom Langfuse API URL.
 - `ignore_usernames` – list of usernames to ignore when processing messages.
 - `instances` – list of monitoring instances. Each instance may contain
   `folders`, `chat_ids`, `entities`, `words`, `ignore_words`, `target_chat`,
@@ -40,6 +43,15 @@ python -m src.main
 
 The application will listen to new messages in all configured instances and
 forward those containing any of the specified words to their target chats.
+
+### Langfuse tracing
+
+Set `langfuse_public_key` and `langfuse_secret_key` in the config to enable
+tracing with [Langfuse](https://langfuse.com). Optionally specify
+`langfuse_base_url` if using a self-hosted instance.
+The bot uses the Langfuse OpenAI integration, so all OpenAI calls are
+automatically traced. Each request is tagged with the instance name and chat
+name to make debugging easier.
 
 ## Development
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -4,6 +4,9 @@ session: data/session
 log_level: info
 openai_api_key: ""
 openai_model: gpt-4.1-mini
+langfuse_public_key: ""
+langfuse_secret_key: ""
+langfuse_base_url: ""
 ignore_usernames: []
 instances:
   - name: default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "telethon",
     "PyYAML",
     "openai",
+    "langfuse",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest-asyncio
 pytest-cov
 coverage
 openai
+langfuse

--- a/src/app.py
+++ b/src/app.py
@@ -4,7 +4,7 @@ from typing import List
 
 from telethon import TelegramClient, events, types
 
-from . import prompts, telegram_utils
+from . import langfuse_utils, prompts, telegram_utils
 from .config import Instance, get_api_credentials, load_config, load_instances
 from .prompts import Prompt, match_prompt
 from .stats import stats as global_stats
@@ -25,6 +25,8 @@ logger = logging.getLogger(__name__)
 client: TelegramClient | None = None
 config: dict = {}
 instances: List[Instance] = []
+
+langfuse_client = None
 
 # Use shared stats tracker
 stats = global_stats
@@ -97,7 +99,7 @@ async def process_message(inst: Instance, event: events.NewMessage.Event) -> Non
             used_word = w
         else:
             for p in inst.prompts:
-                res = await match_prompt(p, message.raw_text, inst.name)
+                res = await match_prompt(p, message.raw_text, inst.name, chat_name)
                 sc = res.similarity
                 if sc > used_score:
                     used_score = sc
@@ -200,6 +202,9 @@ async def main() -> None:
     global client, instances, config
     config = load_config()
     prompts.config.update(config)
+    global langfuse_client
+    langfuse_client = langfuse_utils.init_langfuse(config)
+    prompts.langfuse_client = langfuse_client
 
     setup_logging(config.get("log_level", "info"))
 

--- a/src/langfuse_utils.py
+++ b/src/langfuse_utils.py
@@ -1,0 +1,22 @@
+import logging
+from typing import Optional
+
+try:
+    from langfuse import Langfuse
+except Exception:  # pragma: no cover - package optional
+    Langfuse = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def init_langfuse(config: dict) -> Optional["Langfuse"]:
+    """Initialize and return a Langfuse client if credentials are present."""
+    if Langfuse is None:
+        logger.info("Langfuse package not available")
+        return None
+    public_key = config.get("langfuse_public_key")
+    secret_key = config.get("langfuse_secret_key")
+    base_url = config.get("langfuse_base_url")
+    if not public_key or not secret_key:
+        return None
+    return Langfuse(public_key=public_key, secret_key=secret_key, host=base_url)

--- a/tests/test_langfuse.py
+++ b/tests/test_langfuse.py
@@ -1,0 +1,67 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import src.langfuse_utils as lfu
+import src.prompts as prompts
+
+
+class DummyLangfuse:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.events = []
+
+    def create_event(self, **kwargs):
+        self.events.append(kwargs)
+
+
+def test_init_langfuse(monkeypatch):
+    recorded = {}
+
+    def fake_langfuse(**kwargs):
+        recorded.update(kwargs)
+        return "client"
+
+    monkeypatch.setattr(lfu, "Langfuse", fake_langfuse)
+    cfg = {
+        "langfuse_public_key": "pk",
+        "langfuse_secret_key": "sk",
+        "langfuse_base_url": "url",
+    }
+    client = lfu.init_langfuse(cfg)
+    assert client == "client"
+    assert recorded == {"public_key": "pk", "secret_key": "sk", "host": "url"}
+
+
+@pytest.mark.asyncio
+async def test_match_prompt_logs(monkeypatch):
+    dummy = DummyLangfuse()
+    prompts.langfuse_client = dummy
+    prompts.config["openai_api_key"] = "k"
+
+    result_obj = prompts.EvaluateResult(similarity=4, main_fragment="f")
+
+    recorded = {}
+
+    class DummyCompletions:
+        def parse(self, **kwargs):
+            recorded.update(kwargs)
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(parsed=result_obj))]
+            )
+
+    class DummyClient:
+        def __init__(self, api_key=None, http_client=None):
+            self.chat = SimpleNamespace(completions=DummyCompletions())
+
+    monkeypatch.setattr(prompts.openai, "OpenAI", DummyClient)
+
+    prompt = prompts.Prompt(name="p", prompt="p")
+    res = await prompts.match_prompt(prompt, "text", "i", "c")
+
+    assert res == result_obj
+    assert dummy.events[0]["name"] == "p"
+    assert dummy.events[0]["input"] == {"prompt": "p", "text": "text"}
+    assert dummy.events[0]["output"] == result_obj.model_dump()
+    assert recorded["metadata"] == {"langfuse_tags": ["i", "c"]}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -159,6 +159,7 @@ async def test_match_prompt(monkeypatch):
             messages=None,
             response_format=None,
             response_model=None,
+            metadata=None,
         ):  # noqa: D401 - test stub
             prompt = messages[0]["content"].split("\n", 1)[0]
             calls.append(prompt)
@@ -174,10 +175,10 @@ async def test_match_prompt(monkeypatch):
         def __init__(self, api_key=None, http_client=None):  # noqa: D401 - test stub
             self.chat = SimpleNamespace(completions=DummyCompletions())
 
-    monkeypatch.setattr(prompts, "OpenAI", DummyClient)
+    monkeypatch.setattr(prompts.openai, "OpenAI", DummyClient)
     prompts.config["openai_api_key"] = "k"
     prompt = prompts.Prompt(name="p1", prompt="p1", threshold=2)
-    result = await prompts.match_prompt(prompt, "msg", "i")
+    result = await prompts.match_prompt(prompt, "msg", "i", "c")
     assert result.similarity == 3
     assert calls == ["p1"]
 

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -137,9 +137,10 @@ async def test_process_message_prompt(monkeypatch, dummy_message_cls, tmp_path):
         target_chat=1,
     )
 
-    async def fake_match(prompt, text, inst_name):
+    async def fake_match(prompt, text, inst_name, chat_name):
         assert prompt.prompt == "hi"
         assert inst_name == "p"
+        assert chat_name == "n"
         return prompts.EvaluateResult(similarity=5, main_fragment="")
 
     async def fake_get_message_source(msg):
@@ -151,6 +152,7 @@ async def test_process_message_prompt(monkeypatch, dummy_message_cls, tmp_path):
     monkeypatch.setattr(app, "match_prompt", fake_match)
     monkeypatch.setattr(tgu, "get_message_source", fake_get_message_source)
     monkeypatch.setattr(tgu, "get_chat_name", fake_get_chat_name)
+    monkeypatch.setattr(app, "get_chat_name", fake_get_chat_name)
 
     msg = dummy_message_cls(SimpleNamespace(channel_id=1), msg_id=7, text="hi")
     event = SimpleNamespace(message=msg, chat_id=1)


### PR DESCRIPTION
## Summary
- add `langfuse` dependency
- configure example with Langfuse credentials
- implement Langfuse client initialization
- integrate tracing into prompt matching
- log matches to Langfuse when configured
- document Langfuse settings
- test Langfuse integration

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a6c014bbc832c939c0b0383fc6e27