### PR TITLE
Add ignore_user_ids feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ pip install -r requirements.txt
 - `langfuse_secret_key` – (optional) secret key for Langfuse.
 - `langfuse_base_url` – (optional) custom Langfuse API URL.
 - `ignore_usernames` – list of usernames to ignore when processing messages.
+- `ignore_user_ids` – list of user IDs to ignore when processing messages.
 - `instances` – list of monitoring instances. Each instance may contain
   `folders`, `chat_ids`, `entities`, `words`, `ignore_words`, `target_chat`,
   `target_entity`, `folder_mute`, `false_positive_entity` and `true_positive_entity`.

--- a/config-example.yml
+++ b/config-example.yml
@@ -8,6 +8,7 @@ langfuse_public_key: ""
 langfuse_secret_key: ""
 langfuse_base_url: ""
 ignore_usernames: []
+ignore_user_ids: []
 instances:
   - name: default
     entities:

--- a/src/app.py
+++ b/src/app.py
@@ -234,6 +234,10 @@ async def main() -> None:
     @client.on(events.NewMessage)
     async def handler(event: events.NewMessage.Event) -> None:
         username = getattr(getattr(event.message, "sender", None), "username", None)
+        user_id = getattr(getattr(event.message, "sender", None), "id", None)
+        if user_id and user_id in config.get("ignore_user_ids", []):
+            logger.debug("Ignoring message from id %s", user_id)
+            return
         if username and username.lower() in [
             u.lower() for u in config.get("ignore_usernames", [])
         ]:

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -216,6 +216,59 @@ async def test_ignore_usernames(
 
 
 @pytest.mark.asyncio
+async def test_ignore_user_ids(
+    monkeypatch, dummy_tg_client, dummy_message_cls, tmp_path
+):
+    config = {"log_level": "info", "ignore_user_ids": [42]}
+    monkeypatch.setattr(app, "load_config", lambda: config)
+    monkeypatch.setattr(app, "get_api_credentials", lambda cfg: (1, "h", "s"))
+
+    dummy_client = dummy_tg_client
+    monkeypatch.setattr(app, "TelegramClient", lambda s, a, b: dummy_client)
+
+    stats_path = tmp_path / "stats.json"
+    monkeypatch.setattr(
+        app, "stats", stats_module.StatsTracker(str(stats_path), flush_interval=0)
+    )
+
+    async def fake_rescan(inst):
+        return None
+
+    monkeypatch.setattr(app, "rescan_loop", fake_rescan)
+
+    async def fake_update(inst, fr):
+        inst.chat_ids = {1}
+
+    monkeypatch.setattr(app, "update_instance_chat_ids", fake_update)
+
+    async def fake_load_instances(cfg):
+        return [app.Instance(name="i", words=["hi"], target_chat=99)]
+
+    monkeypatch.setattr(app, "load_instances", fake_load_instances)
+
+    async def fake_get_message_source(m):
+        return "URL"
+
+    monkeypatch.setattr(tgu, "get_message_source", fake_get_message_source)
+
+    async def fake_get_chat_name(v, safe=False):
+        return "name"
+
+    monkeypatch.setattr(tgu, "get_chat_name", fake_get_chat_name)
+
+    await app.main()
+
+    handler = dummy_client.on_handler
+    msg = dummy_message_cls(SimpleNamespace(channel_id=1), msg_id=5, text="hi")
+    msg.sender = SimpleNamespace(id=42)
+    event = SimpleNamespace(message=msg, chat_id=1)
+    await handler(event)
+    assert msg.forwarded == []
+    assert dummy_client.sent == []
+    assert app.stats.data["total"] == 0
+
+
+@pytest.mark.asyncio
 async def test_false_positive_reaction(monkeypatch, dummy_message_cls):
     msg = dummy_message_cls(SimpleNamespace(channel_id=77), msg_id=5, text="hi")
 


### PR DESCRIPTION
## Summary
- allow ignoring users by ID in handler
- document `ignore_user_ids` in README and config-example
- test ignoring by ID

## Testing
- `pre-commit run --all-files`
- `OTEL_SDK_DISABLED=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7b22df68832cadebea1f4b832161