### PR TITLE
Add negative words handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install -r requirements.txt
 - `langfuse_base_url` – (optional) custom Langfuse API URL.
 - `ignore_usernames` – list of usernames to ignore when processing messages.
 - `instances` – list of monitoring instances. Each instance may contain
-  `folders`, `chat_ids`, `entities`, `words`, `ignore_words`, `target_chat`,
+  `folders`, `chat_ids`, `entities`, `words`, `negative_words`, `ignore_words`, `target_chat`,
   `target_entity`, `folder_mute`, `false_positive_entity` and `true_positive_entity`.
 
 ## Running

--- a/config-example.yml
+++ b/config-example.yml
@@ -15,6 +15,7 @@ instances:
     folders: []
     folder_mute: false
     words: ["my username"]
+    negative_words: []
     ignore_words: []
     prompts:
       - name: example

--- a/src/app.py
+++ b/src/app.py
@@ -89,6 +89,13 @@ async def process_message(inst: Instance, event: events.NewMessage.Event) -> Non
             inst.name,
         )
         return
+    if message.raw_text and word_in_text(inst.negative_words, message.raw_text):
+        logger.debug(
+            "Ignoring message %s for %s due to negative_words",
+            message.id,
+            inst.name,
+        )
+        return
     stats.increment(inst.name)
     chat_name = await get_chat_name(event.chat_id, safe=True)
     forward = False

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,7 @@ class Instance:
 
     name: str
     words: List[str]
+    negative_words: List[str] = field(default_factory=list)
     ignore_words: List[str] = field(default_factory=list)
     target_chat: int | None = None
     target_entity: str | None = None
@@ -58,6 +59,7 @@ async def load_instances(config: dict) -> List[Instance]:
                     "chat_ids": config.get("chat_ids", []),
                     "entities": config.get("entities", []),
                     "words": config.get("words", []),
+                    "negative_words": config.get("negative_words", []),
                     "ignore_words": config.get("ignore_words", []),
                     "target_chat": config.get("target_chat"),
                     "target_entity": config.get("target_entity"),
@@ -94,6 +96,7 @@ async def load_instances(config: dict) -> List[Instance]:
             chat_ids=set(inst_cfg.get("chat_ids", [])),
             entities=inst_cfg.get("entities", []),
             words=inst_cfg.get("words", []),
+            negative_words=inst_cfg.get("negative_words", []),
             ignore_words=inst_cfg.get("ignore_words", []),
             target_chat=inst_cfg.get("target_chat"),
             target_entity=inst_cfg.get("target_entity"),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -141,10 +141,22 @@ def test_load_instances_ignore_words():
     assert instances[0].ignore_words == ["bad"]
 
 
+def test_load_instances_negative_words():
+    config = {"instances": [{"name": "i", "words": [], "negative_words": ["bad"]}]}
+    instances = asyncio.run(config_module.load_instances(config))
+    assert instances[0].negative_words == ["bad"]
+
+
 def test_load_instances_ignore_words_backward():
     config = {"words": [], "ignore_words": ["bad"]}
     instances = asyncio.run(config_module.load_instances(config))
     assert instances[0].ignore_words == ["bad"]
+
+
+def test_load_instances_negative_words_backward():
+    config = {"words": [], "negative_words": ["bad"]}
+    instances = asyncio.run(config_module.load_instances(config))
+    assert instances[0].negative_words == ["bad"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -350,3 +350,57 @@ async def test_ignore_words(monkeypatch, dummy_tg_client, dummy_message_cls, tmp
     assert msg.forwarded == []
     assert dummy_client.sent == []
     assert app.stats.data["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_negative_words(
+    monkeypatch, dummy_tg_client, dummy_message_cls, tmp_path
+):
+    config = {"log_level": "info"}
+    monkeypatch.setattr(app, "load_config", lambda: config)
+    monkeypatch.setattr(app, "get_api_credentials", lambda cfg: (1, "h", "s"))
+
+    dummy_client = dummy_tg_client
+    monkeypatch.setattr(app, "TelegramClient", lambda s, a, b: dummy_client)
+
+    stats_path = tmp_path / "stats.json"
+    monkeypatch.setattr(
+        app, "stats", stats_module.StatsTracker(str(stats_path), flush_interval=0)
+    )
+
+    async def fake_rescan(inst):
+        return None
+
+    monkeypatch.setattr(app, "rescan_loop", fake_rescan)
+
+    async def fake_update(inst, fr):
+        inst.chat_ids = {1}
+
+    monkeypatch.setattr(app, "update_instance_chat_ids", fake_update)
+
+    async def fake_load_instances(cfg):
+        return [
+            app.Instance(name="i", words=["hi"], negative_words=["bad"], target_chat=99)
+        ]
+
+    monkeypatch.setattr(app, "load_instances", fake_load_instances)
+
+    async def fake_get_message_source(m):
+        return "URL"
+
+    monkeypatch.setattr(tgu, "get_message_source", fake_get_message_source)
+
+    async def fake_get_chat_name(v, safe=False):
+        return "name"
+
+    monkeypatch.setattr(tgu, "get_chat_name", fake_get_chat_name)
+
+    await app.main()
+
+    handler = dummy_client.on_handler
+    msg = dummy_message_cls(SimpleNamespace(channel_id=1), msg_id=5, text="bad hi")
+    event = SimpleNamespace(message=msg, chat_id=1)
+    await handler(event)
+    assert msg.forwarded == []
+    assert dummy_client.sent == []
+    assert app.stats.data["total"] == 0


### PR DESCRIPTION
## Summary
- introduce `negative_words` in instance config
- ignore messages containing negative words before matching
- document the new option in README and example config
- test negative words handling and config parsing

## Testing
- `pre-commit run --all-files`
- `OTEL_SDK_DISABLED=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7c06ca48832c83d33c2f74d3a2d0