### PR TITLE
Update stats format with conversion utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ python -m src.main
 The application will listen to new messages in all configured instances and
 forward those containing any of the specified words to their target chats.
 
+Statistics about processed messages are stored in `data/stats.json`. If you
+have a file in the old format (without the `stats` section), it will be
+automatically converted on startup using the new `Stats` structure.
+
 ### Langfuse tracing
 
 Set `langfuse_public_key` and `langfuse_secret_key` in the config to enable

--- a/src/stats.py
+++ b/src/stats.py
@@ -4,10 +4,68 @@ import json
 import logging
 import os
 import time
+from dataclasses import asdict, dataclass
 
 logger = logging.getLogger(__name__)
 
 STATS_PATH = os.path.join("data", "stats.json")
+
+
+@dataclass
+class Stats:
+    """Statistics counters for processed messages."""
+
+    total: int = 0
+    forwarded_total: int = 0
+    forwarded_words: int = 0
+    forwarded_prompt: int = 0
+    tokens: int = 0
+
+    @classmethod
+    def from_dict(cls, data: dict | None) -> "Stats":
+        data = data or {}
+        return cls(
+            total=data.get("total", 0),
+            forwarded_total=data.get("forwarded_total", 0),
+            forwarded_words=data.get("forwarded_words", 0),
+            forwarded_prompt=data.get("forwarded_prompt", 0),
+            tokens=data.get("tokens", 0),
+        )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def convert(data: dict) -> dict:
+    """Convert stats from the old format to the new one."""
+
+    if "stats" in data:
+        return data
+
+    new_data = {
+        "stats": Stats(
+            total=data.get("total", 0), tokens=data.get("tokens", 0)
+        ).to_dict(),
+        "instances": [],
+    }
+
+    for inst in data.get("instances", []):
+        inst_data = {
+            "name": inst.get("name"),
+            "stats": Stats(
+                total=inst.get("total", 0), tokens=inst.get("tokens", 0)
+            ).to_dict(),
+            "days": {},
+            "tokens": inst.get("tokens", 0),
+        }
+        for day, val in inst.get("days", {}).items():
+            if isinstance(val, dict) and "stats" in val:
+                inst_data["days"][day] = val
+            else:
+                inst_data["days"][day] = {"stats": Stats(total=val).to_dict()}
+        new_data["instances"].append(inst_data)
+
+    return new_data
 
 
 class StatsTracker:
@@ -18,30 +76,33 @@ class StatsTracker:
         self.flush_interval = flush_interval
         self.last_flush = time.monotonic()
         self.dirty = False
-        self.data = {"total": 0, "tokens": 0, "instances": []}
+        self.data = {"stats": Stats().to_dict(), "instances": []}
         if os.path.exists(path):
             try:
                 with open(path, "r", encoding="utf-8") as f:
                     self.data = json.load(f)
+                if "stats" not in self.data:
+                    self.data = convert(self.data)
             except Exception:  # pragma: no cover - corrupt file
-                self.data = {"total": 0, "tokens": 0, "instances": []}
-        self.data.setdefault("tokens", 0)
+                self.data = {"stats": Stats().to_dict(), "instances": []}
 
     def _get_inst(self, name: str) -> dict:
         for inst in self.data.get("instances", []):
             if inst.get("name") == name:
+                inst.setdefault("stats", Stats().to_dict())
                 inst.setdefault("tokens", 0)
                 return inst
-        inst = {"name": name, "total": 0, "tokens": 0, "days": {}}
+        inst = {"name": name, "stats": Stats().to_dict(), "days": {}, "tokens": 0}
         self.data.setdefault("instances", []).append(inst)
         return inst
 
     def increment(self, name: str) -> None:
         inst = self._get_inst(name)
-        self.data["total"] = self.data.get("total", 0) + 1
-        inst["total"] = inst.get("total", 0) + 1
+        self.data["stats"]["total"] = self.data["stats"].get("total", 0) + 1
+        inst["stats"]["total"] = inst["stats"].get("total", 0) + 1
         day = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d")
-        inst["days"][day] = inst["days"].get(day, 0) + 1
+        day_stat = inst["days"].setdefault(day, {"stats": Stats().to_dict()})
+        day_stat["stats"]["total"] = day_stat["stats"].get("total", 0) + 1
         self.dirty = True
         if time.monotonic() - self.last_flush >= self.flush_interval:
             self.flush()
@@ -50,7 +111,8 @@ class StatsTracker:
         if tokens <= 0:
             return
         inst = self._get_inst(name)
-        self.data["tokens"] = self.data.get("tokens", 0) + tokens
+        self.data["stats"]["tokens"] = self.data["stats"].get("tokens", 0) + tokens
+        inst["stats"]["tokens"] = inst["stats"].get("tokens", 0) + tokens
         inst["tokens"] = inst.get("tokens", 0) + tokens
         self.dirty = True
         if time.monotonic() - self.last_flush >= self.flush_interval:

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -110,10 +110,10 @@ async def test_main_flow(monkeypatch, dummy_tg_client, dummy_message_cls, tmp_pa
     assert dummy_client.sent[0][0][0] == 99
     assert dummy_client.sent[1][0][0] == "name"
     data = json.loads(stats_path.read_text())
-    assert data["total"] == 1
+    assert data["stats"]["total"] == 1
     inst = data["instances"][0]
     assert inst["name"] == "i"
-    assert inst["total"] == 1
+    assert inst["stats"]["total"] == 1
 
 
 @pytest.mark.asyncio
@@ -212,7 +212,7 @@ async def test_ignore_usernames(
     await handler(event)
     assert msg.forwarded == []
     assert dummy_client.sent == []
-    assert app.stats.data["total"] == 0
+    assert app.stats.data["stats"]["total"] == 0
 
 
 @pytest.mark.asyncio
@@ -265,7 +265,7 @@ async def test_ignore_user_ids(
     await handler(event)
     assert msg.forwarded == []
     assert dummy_client.sent == []
-    assert app.stats.data["total"] == 0
+    assert app.stats.data["stats"]["total"] == 0
 
 
 @pytest.mark.asyncio
@@ -402,7 +402,7 @@ async def test_ignore_words(monkeypatch, dummy_tg_client, dummy_message_cls, tmp
     await handler(event)
     assert msg.forwarded == []
     assert dummy_client.sent == []
-    assert app.stats.data["total"] == 0
+    assert app.stats.data["stats"]["total"] == 0
 
 
 @pytest.mark.asyncio
@@ -456,4 +456,4 @@ async def test_negative_words(
     await handler(event)
     assert msg.forwarded == []
     assert dummy_client.sent == []
-    assert app.stats.data["total"] == 0
+    assert app.stats.data["stats"]["total"] == 0

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -13,13 +13,30 @@ def test_stats_increment_and_flush(tmp_path):
     tracker.add_tokens("b", 5)
     tracker.flush()
     data = json.loads(path.read_text())
-    assert data["total"] == 3
-    assert data["tokens"] == 15
+    assert data["stats"]["total"] == 3
+    assert data["stats"]["tokens"] == 15
     inst_a = next(i for i in data["instances"] if i["name"] == "a")
     inst_b = next(i for i in data["instances"] if i["name"] == "b")
-    assert inst_a["total"] == 2
-    assert inst_b["total"] == 1
-    assert inst_a["tokens"] == 10
-    assert inst_b["tokens"] == 5
+    assert inst_a["stats"]["total"] == 2
+    assert inst_b["stats"]["total"] == 1
+    assert inst_a["stats"]["tokens"] == 10
+    assert inst_b["stats"]["tokens"] == 5
     day = list(inst_a["days"].keys())[0]
-    assert inst_a["days"][day] == 2
+    assert inst_a["days"][day]["stats"]["total"] == 2
+
+
+def test_convert_old_format():
+    old = {
+        "total": 1,
+        "tokens": 2,
+        "instances": [
+            {"name": "a", "total": 1, "tokens": 2, "days": {"2024-01-01": 1}}
+        ],
+    }
+    new = stats_module.convert(old)
+    assert new["stats"]["total"] == 1
+    inst = new["instances"][0]
+    assert inst["name"] == "a"
+    assert inst["stats"]["total"] == 1
+    assert inst["stats"]["tokens"] == 2
+    assert inst["days"]["2024-01-01"]["stats"]["total"] == 1


### PR DESCRIPTION
## Summary
- add `Stats` dataclass and new hierarchical structure
- implement `convert` function and use it in `StatsTracker`
- adjust README to mention automatic stats conversion
- update tests for new stats layout

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c78083a00832c9ee041917e2b0e04