### PR TITLE
Avoid duplicate reaction forwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ matching messages to a target chat.
 - Multiple instances for different chats, words and targets
 - Each instance has target chat
 - Forwarded messages include a link to the original message
+- Reactions (👍/👎) forward messages to true/false positive chats once per message
 
 ## Setup
 

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -312,6 +312,52 @@ async def test_false_positive_reaction(monkeypatch, dummy_message_cls):
 
 
 @pytest.mark.asyncio
+async def test_negative_reaction_twice(monkeypatch, dummy_message_cls):
+    msg = dummy_message_cls(SimpleNamespace(channel_id=77), msg_id=5, text="hi")
+
+    class DummyClient:
+        async def get_messages(self, peer, ids):
+            return msg
+
+        async def get_entity(self, ident):
+            return SimpleNamespace(channel_id=77)
+
+    app.client = DummyClient()
+    tgu.client = app.client
+    app.forwarded_positive.clear()
+    app.forwarded_negative.clear()
+    inst = app.Instance(
+        name="i",
+        words=[],
+        target_entity="t",
+        false_positive_entity="fp",
+    )
+    app.instances = [inst]
+
+    update = tgu.types.UpdateMessageReactions(
+        peer=tgu.types.PeerChannel(77),
+        msg_id=5,
+        reactions=tgu.types.MessageReactions(
+            results=[tgu.types.ReactionCount(tgu.types.ReactionEmoji("\U0001F44E"), 1)]
+        ),
+    )
+
+    async def fake_to_event_chat_id(peer):
+        return 77
+
+    async def fake_get_forward_message_text(m, **kwargs):
+        return "src"
+
+    monkeypatch.setattr(tgu, "to_event_chat_id", fake_to_event_chat_id)
+    monkeypatch.setattr(tgu, "get_forward_message_text", fake_get_forward_message_text)
+
+    await app.handle_reaction(update)
+    await app.handle_reaction(update)
+
+    assert msg.forwarded == ["fp"]
+
+
+@pytest.mark.asyncio
 async def test_true_positive_reaction(monkeypatch, dummy_message_cls):
     msg = dummy_message_cls(SimpleNamespace(channel_id=77), msg_id=5, text="hi")
 
@@ -348,6 +394,51 @@ async def test_true_positive_reaction(monkeypatch, dummy_message_cls):
     monkeypatch.setattr(tgu, "to_event_chat_id", fake_to_event_chat_id)
     monkeypatch.setattr(tgu, "get_forward_message_text", fake_get_forward_message_text)
 
+    await app.handle_reaction(update)
+
+    assert msg.forwarded == ["tp"]
+
+
+@pytest.mark.asyncio
+async def test_positive_reaction_twice(monkeypatch, dummy_message_cls):
+    msg = dummy_message_cls(SimpleNamespace(channel_id=77), msg_id=5, text="hi")
+
+    class DummyClient:
+        async def get_messages(self, peer, ids):
+            return msg
+
+        async def get_entity(self, ident):
+            return SimpleNamespace(channel_id=77)
+
+    app.client = DummyClient()
+    app.forwarded_positive.clear()
+    app.forwarded_negative.clear()
+    inst = app.Instance(
+        name="i",
+        words=[],
+        target_entity="t",
+        true_positive_entity="tp",
+    )
+    app.instances = [inst]
+
+    update = tgu.types.UpdateMessageReactions(
+        peer=tgu.types.PeerChannel(77),
+        msg_id=5,
+        reactions=tgu.types.MessageReactions(
+            results=[tgu.types.ReactionCount(tgu.types.ReactionEmoji("\U0001F44D"), 1)]
+        ),
+    )
+
+    async def fake_to_event_chat_id(peer):
+        return 77
+
+    async def fake_get_forward_message_text(m, **kwargs):
+        return "src"
+
+    monkeypatch.setattr(tgu, "to_event_chat_id", fake_to_event_chat_id)
+    monkeypatch.setattr(tgu, "get_forward_message_text", fake_get_forward_message_text)
+
+    await app.handle_reaction(update)
     await app.handle_reaction(update)
 
     assert msg.forwarded == ["tp"]


### PR DESCRIPTION
## Summary
- prevent forwarding the same reacted message twice
- track forwarded reactions in memory
- test reaction forwarding idempotence
- document reaction forwarding once

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c8831010c832c82db0448ab1da52f