### PR TITLE
Update prompt evaluation schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ matching messages to a target chat.
 - Multiple instances for different chats, words and targets
 - Each instance has target chat
 - Forwarded messages include a link to the original message
+- Prompt-triggered forwards include a short reason and quote from the message
 - Reactions (👍/👎) forward messages to true/false positive chats once per message
 
 ## Setup

--- a/src/app.py
+++ b/src/app.py
@@ -106,7 +106,8 @@ async def process_message(inst: Instance, event: events.NewMessage.Event) -> Non
     used_word: str | None = None
     used_prompt: Prompt | None = None
     used_score = 0
-    used_fragment: str | None = None
+    used_quote: str | None = None
+    used_reasoning: str | None = None
 
     if message.raw_text:
         w = find_word(inst.words, message.raw_text)
@@ -116,11 +117,12 @@ async def process_message(inst: Instance, event: events.NewMessage.Event) -> Non
         else:
             for p in inst.prompts:
                 res = await match_prompt(p, message.raw_text, inst.name, chat_name)
-                sc = res.similarity
+                sc = res.score
                 if sc > used_score:
                     used_score = sc
                     used_prompt = p
-                    used_fragment = res.main_fragment
+                    used_quote = res.quote
+                    used_reasoning = res.reasoning
                 if sc >= (p.threshold or 4):
                     forward = True
                     break
@@ -132,7 +134,8 @@ async def process_message(inst: Instance, event: events.NewMessage.Event) -> Non
                     prompt=used_prompt,
                     score=used_score,
                     word=used_word,
-                    fragment=used_fragment,
+                    quote=used_quote,
+                    reasoning=used_reasoning,
                 )
             destinations = []
             dest_names = []

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -117,9 +117,17 @@ async def load_langfuse_prompt(prompt: Prompt):
 class EvaluateResult(BaseModel):
     """Result returned by LLM evaluation."""
 
-    reasoning: Annotated[str, Field(max_length=100)] = ""
-    quote: Annotated[str, Field(max_length=100)] = ""
-    score: Annotated[int, Field(ge=0, le=5)] = 0
+    reasoning: Annotated[
+        str, Field(max_length=100, description="Краткое объяснение без цитат, RU")
+    ] = ""
+    quote: Annotated[
+        str,
+        Field(
+            max_length=100,
+            description="Оригинальный фрагмент сообщения, демонстрирующий максимум недовольства",
+        ),
+    ] = ""
+    score: Annotated[int, Field(ge=0, le=5, description="Уровень")] = 0
 
 
 @observe()

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -50,13 +50,7 @@ class Prompt:
 
 def build_prompt(prompt: Prompt) -> str:
     """Construct final system prompt for LLM evaluation."""
-    compiled = (
-        f"{prompt.prompt}\n\n"
-        "Produce one JSON object with three keys only:\n"
-        '- "reasoning" \u2013 a short explanation (\u2264 100 chars, Russian)\n'
-        '- "quote" - \u2264200 original chars showing max dissatisfaction\n'
-        '- "score" \u2013 an integer 0-5'
-    )
+    compiled = f"{prompt.prompt}"
     prompt._compiled_prompt = compiled
     return compiled
 
@@ -181,7 +175,9 @@ async def match_prompt(
     except Exception as exc:  # pragma: no cover - external call
         logger.error("Failed to query OpenAI: %s", exc)
         result = EvaluateResult(score=0, reasoning="", quote="")
-    logger.debug("Prompt check: %s -> %s", prompt.name, result.score)
+    logger.debug(
+        '%s - %s: %s - "%s"', prompt.name, result.score, result.reasoning, result.quote
+    )
 
     if langfuse is not None:
         try:

--- a/src/telegram_utils.py
+++ b/src/telegram_utils.py
@@ -128,7 +128,8 @@ def get_forward_reason_text(
     prompt=None,
     score: int | None = None,
     word: str | None = None,
-    fragment: str | None = None,
+    quote: str | None = None,
+    reasoning: str | None = None,
 ) -> str:
     """Return human-readable reason for forwarding a message."""
     if word:
@@ -136,8 +137,10 @@ def get_forward_reason_text(
     if prompt is not None and score is not None:
         name = getattr(prompt, "name", None) or "prompt"
         reason = f"{name}: {score}/5"
-        if fragment:
-            reason += f" - `{fragment}`"
+        if quote:
+            reason += f" - `{quote}`"
+        if reasoning:
+            return f"{reason}\n\n{reasoning}"
         return reason
     return ""
 
@@ -148,11 +151,16 @@ async def get_forward_message_text(
     prompt=None,
     score: int | None = None,
     word: str | None = None,
-    fragment: str | None = None,
+    quote: str | None = None,
+    reasoning: str | None = None,
 ) -> str:
     """Return text to send before forwarding ``message``."""
     reason = get_forward_reason_text(
-        prompt=prompt, score=score, word=word, fragment=fragment
+        prompt=prompt,
+        score=score,
+        word=word,
+        quote=quote,
+        reasoning=reasoning,
     )
     source = await get_message_source(message)
     if reason:

--- a/tests/test_langfuse.py
+++ b/tests/test_langfuse.py
@@ -51,7 +51,7 @@ async def test_match_prompt_logs(monkeypatch):
     monkeypatch.setattr(prompts, "langfuse", dummy)
     prompts.config["openai_api_key"] = "k"
 
-    result_obj = prompts.EvaluateResult(similarity=4, main_fragment="f")
+    result_obj = prompts.EvaluateResult(score=4, reasoning="", quote="f")
 
     recorded = {}
 
@@ -169,7 +169,7 @@ async def test_match_prompt_lf_config(monkeypatch):
     monkeypatch.setattr(prompts, "langfuse", dummy)
     prompts.config["openai_api_key"] = "k"
 
-    result_obj = prompts.EvaluateResult(similarity=3, main_fragment="f")
+    result_obj = prompts.EvaluateResult(score=3, reasoning="", quote="f")
     recorded = {}
 
     class DummyCompletions:

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -141,7 +141,7 @@ async def test_process_message_prompt(monkeypatch, dummy_message_cls, tmp_path):
         assert prompt.prompt == "hi"
         assert inst_name == "p"
         assert chat_name == "n"
-        return prompts.EvaluateResult(similarity=5, main_fragment="")
+        return prompts.EvaluateResult(score=5, reasoning="", quote="")
 
     async def fake_get_message_source(msg):
         return "src"


### PR DESCRIPTION
## Summary
- overhaul prompt evaluation: store `reasoning`, `quote` and `score`
- update system prompt builder to reflect new JSON output
- adapt app logic to new fields
- adjust unit tests
- show reasoning when forwarding prompt-based messages

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d1fa49868832c827c4a548aa4575b