### PR TITLE
Add run_deepeval command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 data/
+.deepeval

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,14 @@
             "program": "-m",
             "args": ["src.generate_evals", "--suffix", "main"],
             "console": "integratedTerminal"
+        },
+        {
+            "name": "run_deepeval --config data/data/config.yml --instance Агентства --prompt Недовольство --suffix main",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "-m",
+            "args": ["src.run_deepeval", "--config", "data/data/config.yml", "--instance", "Агентства", "--prompt", "Недовольство", "--suffix", "main"],
+            "console": "integratedTerminal"
         }
     ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ This project forwards Telegram messages that match specific rules to a target ch
 │   ├── main.py           # CLI entry point
 │   ├── config.py         # config helpers
 │   ├── prompts.py        # OpenAI prompts
+│   ├── evals.py          # evaluation helpers
+│   ├── run_deepeval.py   # run eval datasets
 │   ├── stats.py          # stats tracking
 │   ├── telegram_utils.py # Telegram helpers
 │   ├── generate_evals.py # build eval datasets

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ python -m src.generate_evals --suffix run1
 Datasets and configuration files will be written to `data/evals/` with the
 provided suffix.
 
+## Run evaluations
+
+After generating datasets, run them with [DeepEval](https://github.com/confident-ai/deepeval):
+
+```bash
+python -m src.run_deepeval --instance "Inst" --prompt "Prompt" --suffix run1
+```
+
+Use `--config` to provide a custom path to `config.yml` if needed.
+
 ### Langfuse tracing
 
 Set `langfuse_public_key` and `langfuse_secret_key` in the config to enable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "PyYAML",
     "openai",
     "langfuse",
+    "deepeval",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest-cov
 coverage
 openai
 langfuse
+deepeval

--- a/src/config.py
+++ b/src/config.py
@@ -6,7 +6,8 @@ import yaml
 
 from .prompts import Prompt
 
-CONFIG_PATH = os.path.join("data", "config.yml")
+# Allow overriding config path via environment variable
+CONFIG_PATH = os.environ.get("CONFIG_PATH", os.path.join("data", "config.yml"))
 
 
 @dataclass

--- a/src/evals.py
+++ b/src/evals.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from .telegram_utils import get_safe_name
+
+
+def get_eval_path(instance_name: str, prompt_name: str, suffix: str) -> Path:
+    """Return base path for evaluation data."""
+    inst = get_safe_name(instance_name)
+    prm = get_safe_name(prompt_name)
+    return Path("data") / "evals" / f"{inst}_{prm}_{suffix}"

--- a/src/run_deepeval.py
+++ b/src/run_deepeval.py
@@ -1,0 +1,104 @@
+import argparse
+import asyncio
+import json
+import os
+
+from . import prompts
+from .config import load_config, load_instances
+from .evals import get_eval_path
+
+try:  # pragma: no cover - optional dependency
+    from deepeval import evaluate
+    from deepeval.test_case import LLMTestCase
+    from deepeval.metrics.base_metric import BaseMetric
+except Exception:  # pragma: no cover - optional dependency
+    evaluate = None
+    LLMTestCase = object  # type: ignore
+    BaseMetric = object  # type: ignore
+
+
+async def run_deepeval(
+    instance: str,
+    prompt_name: str,
+    suffix: str,
+    *,
+    config_path: str | None = None,
+) -> float:
+    """Run evaluation for a specific instance and prompt.
+
+    Returns overall accuracy as a float between 0 and 1.
+    """
+    if config_path:
+        os.environ["CONFIG_PATH"] = config_path
+        from . import config as config_module
+
+        config_module.CONFIG_PATH = config_path
+
+    config = load_config()
+    prompts.config.update(config)
+    instances = await load_instances(config)
+
+    inst = next((i for i in instances if i.name == instance), None)
+    if inst is None:
+        raise ValueError(f"Instance not found: {instance}")
+
+    prompt = next((p for p in inst.prompts if p.name == prompt_name), None)
+    if prompt is None:
+        raise ValueError(f"Prompt '{prompt_name}' not found in instance '{instance}'")
+
+    base = get_eval_path(inst.name, prompt.name or "prompt", suffix)
+    msg_path = base / "messages.jsonl"
+    if not msg_path.exists():
+        raise FileNotFoundError(msg_path)
+
+    test_cases = []
+    for line in msg_path.read_text(encoding="utf-8").splitlines():
+        row = json.loads(line)
+        test_cases.append(
+            LLMTestCase(
+                input=row["input"],
+                expected_output=str(row["expected"]["is_match"]).lower(),
+            )
+        )
+
+    for tc in test_cases:
+        res = await prompts.match_prompt(prompt, tc.input)
+        tc.actual_output = str(res.score >= (prompt.threshold or 0)).lower()
+
+    class BoolAccuracyMetric(BaseMetric):
+        def __init__(self) -> None:
+            super().__init__(name="bool_accuracy")
+
+        def measure(self, test_case) -> None:  # type: ignore[override]
+            exp = str(test_case.expected_output).lower()
+            act = str(getattr(test_case, "actual_output", "")).lower()
+            self.score = 1.0 if exp == act else 0.0
+            self.reason = "match" if self.score else f"exp={exp}, got={act}"
+
+    metric = BoolAccuracyMetric()
+    if evaluate is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("deepeval is required to run evaluations")
+    results = evaluate(test_cases, metrics=[metric])
+    return float(results.aggregate_scores.get("bool_accuracy", 0.0))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run DeepEval on saved datasets")
+    parser.add_argument("--config", help="Path to config.yml", default=None)
+    parser.add_argument("--instance", required=True, help="Instance name")
+    parser.add_argument("--prompt", required=True, help="Prompt name")
+    parser.add_argument("--suffix", required=True, help="Dataset suffix")
+    args = parser.parse_args()
+    accuracy = asyncio.run(
+        run_deepeval(
+            args.instance,
+            args.prompt,
+            args.suffix,
+            config_path=args.config,
+        )
+    )
+    print(f"Accuracy: {accuracy:.2%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,3 +24,14 @@ def test_get_api_credentials_success():
 def test_get_api_credentials_missing():
     with pytest.raises(RuntimeError):
         config.get_api_credentials({})
+
+
+def test_config_path_env_override(tmp_path, monkeypatch):
+    cfg = tmp_path / "env.yml"
+    cfg.write_text("bar: 2")
+    monkeypatch.setenv("CONFIG_PATH", str(cfg))
+    import importlib
+
+    cfg_module = importlib.reload(config)
+    assert cfg_module.CONFIG_PATH == str(cfg)
+    assert cfg_module.load_config() == {"bar": 2}

--- a/tests/test_generate_evals.py
+++ b/tests/test_generate_evals.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -6,8 +5,8 @@ from types import SimpleNamespace
 import pytest
 import yaml
 
-import src.generate_evals as ge
 import src.config as config_module
+import src.generate_evals as ge
 
 
 class DummyMessage:

--- a/tests/test_run_deepeval.py
+++ b/tests/test_run_deepeval.py
@@ -1,0 +1,71 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+import src.run_deepeval as rd
+import src.evals as evals
+import src.prompts as prompts
+
+
+@pytest.mark.asyncio
+async def test_run_deepeval(tmp_path, monkeypatch):
+    cfg = {
+        "instances": [
+            {
+                "name": "Inst",
+                "words": [],
+                "prompts": [
+                    {"name": "Prompt", "prompt": "p", "threshold": 2},
+                ],
+            }
+        ]
+    }
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text(yaml.dump(cfg), encoding="utf-8")
+
+    base = evals.get_eval_path("Inst", "Prompt", "suf")
+    base.mkdir(parents=True, exist_ok=True)
+    messages = [
+        {"input": "good", "expected": {"is_match": True}},
+        {"input": "bad", "expected": {"is_match": False}},
+    ]
+    with (base / "messages.jsonl").open("w", encoding="utf-8") as fh:
+        for row in messages:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    async def fake_match_prompt(prompt, text, inst_name=None, chat_name=None):
+        score = 3 if text == "good" else 1
+        return prompts.EvaluateResult(score=score, reasoning="", quote="")
+
+    monkeypatch.setattr(prompts, "match_prompt", fake_match_prompt)
+
+    class DummyTC:
+        def __init__(self, input, expected_output):
+            self.input = input
+            self.expected_output = expected_output
+            self.actual_output = None
+
+    def fake_evaluate(test_cases, metrics):
+        correct = sum(
+            1
+            for tc in test_cases
+            if str(tc.expected_output).lower()
+            == str(tc.actual_output).lower()
+        )
+        acc = correct / len(test_cases)
+        return SimpleNamespace(aggregate_scores={"bool_accuracy": acc})
+
+    class DummyBaseMetric:
+        def __init__(self, name=None):
+            self.name = name
+
+    monkeypatch.setattr(rd, "LLMTestCase", DummyTC)
+    monkeypatch.setattr(rd, "evaluate", fake_evaluate)
+    monkeypatch.setattr(rd, "BaseMetric", DummyBaseMetric)
+
+    acc = await rd.run_deepeval(
+        "Inst", "Prompt", "suf", config_path=str(cfg_path)
+    )
+    assert acc == 1.0


### PR DESCRIPTION
## Summary
- allow configuration file path to be overridden via `CONFIG_PATH`
- add shared helper for evaluation dataset paths
- introduce `run_deepeval` command to execute DeepEval tests

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e8c5c7678832ca4dc32d32d042293