### PR TITLE
feat: enrich DeepEval test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ python -m src.run_deepeval --instance "Inst" --prompt "Prompt" --suffix run1
 ```
 
 Use `--config` to provide a custom path to `config.yml` if needed.
+The command exits with status code `1` if accuracy is below 80%.
 
 ### Langfuse tracing
 

--- a/tests/test_run_deepeval.py
+++ b/tests/test_run_deepeval.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -37,21 +38,28 @@ async def test_run_deepeval(tmp_path, monkeypatch):
 
     async def fake_match_prompt(prompt, text, inst_name=None, chat_name=None):
         score = 3 if text == "good" else 1
-        return prompts.EvaluateResult(score=score, reasoning="", quote="")
+        return SimpleNamespace(
+            score=score,
+            reasoning=f"rsn {text}",
+            quote=f"qt {text}",
+            token_cost=1.0,
+            completion_time=2.0,
+        )
 
     monkeypatch.setattr(prompts, "match_prompt", fake_match_prompt)
 
-    class DummyTC:
-        def __init__(self, input, actual_output, expected_output):
-            self.input = input
-            self.actual_output = actual_output
-            self.expected_output = expected_output
+    created: list[SimpleNamespace] = []
 
-    async def fake_evaluate(test_cases, metrics):
+    class DummyTC(SimpleNamespace):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            created.append(self)
+
+    def fake_evaluate(test_cases, metrics):
         metric = metrics[0]
         results = []
         for tc in test_cases:
-            await metric.a_measure(tc)
+            metric.measure(tc)
             results.append(SimpleNamespace(success=metric.success))
         return SimpleNamespace(test_results=results)
 
@@ -65,3 +73,22 @@ async def test_run_deepeval(tmp_path, monkeypatch):
 
     acc = await rd.run_deepeval("Inst", "Prompt", "suf", config_path=str(cfg_path))
     assert acc == 1.0
+    assert created[0].comments == "rsn good"
+    assert created[0].context == ["qt good"]
+    assert created[0].token_cost == 1.0
+    assert created[0].completion_time == 2.0
+
+
+def test_main_exit_code(monkeypatch):
+    async def fake_run_deepeval(instance, prompt_name, suffix, *, config_path=None):
+        return 0.5
+
+    monkeypatch.setattr(rd, "run_deepeval", fake_run_deepeval)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["rd", "--instance", "i", "--prompt", "p", "--suffix", "s"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        rd.main()
+    assert exc.value.code == 1


### PR DESCRIPTION
## Summary
- include reasoning, quote, token cost and completion time in DeepEval test cases
- exit with status 1 when accuracy drops below 80%
- expand DeepEval tests for new metadata and failure exit code

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ea642353c832cb24fef3793c533f4