### PR TITLE
Add OpenAI Evals runner

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,14 @@
             "program": "-m",
             "args": ["src.run_deepeval", "--config", "data/data/config.yml", "--instance", "Агентства", "--prompt", "Недовольство", "--suffix", "main"],
             "console": "integratedTerminal"
+        },
+        {
+            "name": "run_openai_evals --config data/data/config.yml --instance Агентства --prompt Недовольство --suffix main",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "-m",
+            "args": ["src.run_openai_evals", "--config", "data/data/config.yml", "--instance", "Агентства", "--prompt", "Недовольство", "--suffix", "main"],
+            "console": "integratedTerminal"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ python -m src.run_deepeval --instance "Inst" --prompt "Prompt" --suffix run1
 Use `--config` to provide a custom path to `config.yml` if needed.
 The command exits with status code `1` if accuracy is below 80%.
 
+To evaluate using OpenAI's Evals API:
+
+```bash
+python -m src.run_openai_evals --instance "Inst" --prompt "Prompt" --suffix run1
+```
+
+The runner respects any `model` or `temperature` options defined in the prompt
+configuration and forces JSON responses that match the `EvaluateResult` schema.
+
 ### Langfuse tracing
 
 Set `langfuse_public_key` and `langfuse_secret_key` in the config to enable

--- a/src/generate_evals.py
+++ b/src/generate_evals.py
@@ -94,7 +94,7 @@ metrics: [accuracy]
 To run this evaluation:
 
 ```bash
-openai evals run ./task.yml
+python -m src.run_openai_evals --instance \"{inst.name}\" --prompt \"{prompt.name}\" --suffix {suffix}
 ```
 """
             (base / "README.md").write_text(readme, encoding="utf-8")

--- a/src/run_openai_evals.py
+++ b/src/run_openai_evals.py
@@ -1,0 +1,134 @@
+import argparse
+import asyncio
+import json
+import os
+
+from openai import OpenAI
+
+from .config import load_config, load_instances
+from .evals import get_eval_path
+from .prompts import EvaluateResult
+from .telegram_utils import get_safe_name
+
+
+def run_openai_evals(
+    instance: str,
+    prompt_name: str,
+    suffix: str,
+    *,
+    config_path: str | None = None,
+) -> str:
+    """Run OpenAI evals on previously generated dataset.
+
+    Returns report URL from the created eval run.
+    """
+    if config_path:
+        os.environ["CONFIG_PATH"] = config_path
+        from . import config as config_module
+
+        config_module.CONFIG_PATH = config_path
+
+    config = load_config()
+    instances = asyncio.run(load_instances(config))
+
+    inst = next((i for i in instances if i.name == instance), None)
+    if inst is None:
+        raise ValueError(f"Instance not found: {instance}")
+
+    prompt = next((p for p in inst.prompts if p.name == prompt_name), None)
+    if prompt is None:
+        raise ValueError(f"Prompt '{prompt_name}' not found in instance '{instance}'")
+
+    base = get_eval_path(inst.name, prompt.name or "prompt", suffix)
+    data_path = base / "messages.jsonl"
+    if not data_path.exists():
+        raise FileNotFoundError(data_path)
+
+    client = OpenAI(api_key=config.get("openai_api_key"))
+
+    with data_path.open("rb") as fh:
+        uploaded = client.files.create(file=fh, purpose="evals")
+
+    eval_name = f"{get_safe_name(inst.name)}_{get_safe_name(prompt.name or 'prompt')}"
+
+    eval_obj = client.evals.create(
+        name=eval_name,
+        data_source_config={
+            "type": "custom",
+            "item_schema": {
+                "type": "object",
+                "properties": {
+                    "input": {"type": "string"},
+                    "expected": {
+                        "type": "object",
+                        "properties": {"is_match": {"type": "boolean"}},
+                        "required": ["is_match"],
+                    },
+                },
+                "required": ["input", "expected"],
+            },
+            "include_sample_schema": True,
+        },
+        testing_criteria=[
+            {
+                "type": "python",
+                "name": "Threshold Accuracy",
+                "input": "{{ sample.output_text }}",
+                "reference": "{{ item.expected.is_match }}",
+                "code": (
+                    "import json\n"
+                    "score=json.loads(input)['score']\n"
+                    f"pred=score>={prompt.threshold}\n"
+                    "return int(pred==reference)"
+                ),
+            }
+        ],
+    )
+
+    ds = {
+        "type": "completions",
+        "model": (prompt.config or {}).get("model", "gpt-4.1"),
+        "input_messages": {
+            "type": "template",
+            "template": [
+                {"role": "system", "content": prompt.prompt or ""},
+                {"role": "user", "content": "{{ item.input }}"},
+            ],
+        },
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "EvaluateResult",
+                "schema": EvaluateResult.model_json_schema(),
+            },
+        },
+        "source": {"type": "file_id", "id": uploaded.id},
+    }
+    temperature = (prompt.config or {}).get("temperature")
+    if temperature is not None:
+        ds["sampling_params"] = {"temperature": temperature}
+    run = client.evals.runs.create(
+        eval_obj.id,
+        name=f"{eval_name} run",
+        data_source=ds,
+    )
+
+    return getattr(run, "report_url", "")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run OpenAI evals on saved datasets")
+    parser.add_argument("--config", help="Path to config.yml", default=None)
+    parser.add_argument("--instance", required=True, help="Instance name")
+    parser.add_argument("--prompt", required=True, help="Prompt name")
+    parser.add_argument("--suffix", required=True, help="Dataset suffix")
+    args = parser.parse_args()
+    url = run_openai_evals(
+        args.instance, args.prompt, args.suffix, config_path=args.config
+    )
+    if url:
+        print(f"Report URL: {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_evals.py
+++ b/tests/test_generate_evals.py
@@ -78,3 +78,8 @@ async def test_generate_evals(tmp_path, monkeypatch):
     task = (base / "task.yml").read_text(encoding="utf-8")
     assert "eval_name: Inst_Prompt" in task
     assert "score >= 3" in task
+    readme = (base / "README.md").read_text(encoding="utf-8")
+    assert (
+        'python -m src.run_openai_evals --instance "Inst" --prompt "Prompt" --suffix suf'
+        in readme
+    )

--- a/tests/test_run_openai_evals.py
+++ b/tests/test_run_openai_evals.py
@@ -1,0 +1,81 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+import src.evals as evals
+import src.run_openai_evals as roe
+
+
+class DummyFiles:
+    def __init__(self):
+        self.called = False
+
+    def create(self, file, purpose):  # noqa: D401
+        self.called = True
+        return SimpleNamespace(id="file-1")
+
+
+class DummyEvals:
+    def __init__(self):
+        self.created = None
+        self.run_args = None
+        self.runs = SimpleNamespace(create=self._runs_create)
+
+    def create(self, **kwargs):
+        self.created = kwargs
+        return SimpleNamespace(id="eval-1")
+
+    def _runs_create(self, eval_id, **kwargs):
+        self.run_args = (eval_id, kwargs)
+        return SimpleNamespace(report_url="url")
+
+
+class DummyClient:
+    def __init__(self):
+        self.files = DummyFiles()
+        self.evals = DummyEvals()
+
+
+def test_run_openai_evals(tmp_path, monkeypatch):
+    cfg = {
+        "openai_api_key": "key",
+        "instances": [
+            {
+                "name": "Inst",
+                "words": [],
+                "prompts": [
+                    {
+                        "name": "Prompt",
+                        "prompt": "p",
+                        "threshold": 3,
+                        "config": {"temperature": 0.3},
+                    },
+                ],
+            }
+        ],
+    }
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text(yaml.dump(cfg), encoding="utf-8")
+
+    base = evals.get_eval_path("Inst", "Prompt", "suf")
+    base.mkdir(parents=True, exist_ok=True)
+    with (base / "messages.jsonl").open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"input": "good", "expected": {"is_match": True}}) + "\n")
+
+    dummy = DummyClient()
+    monkeypatch.setattr(roe, "OpenAI", lambda api_key=None: dummy)
+
+    url = roe.run_openai_evals("Inst", "Prompt", "suf", config_path=str(cfg_path))
+    assert url == "url"
+    assert dummy.evals.created["name"] == "Inst_Prompt"
+    assert "score=json.loads" in dummy.evals.created["testing_criteria"][0]["code"]
+    eval_id, run_kwargs = dummy.evals.run_args
+    assert eval_id == "eval-1"
+    ds = run_kwargs["data_source"]
+    assert ds["source"]["id"] == "file-1"
+    tmpl = ds["input_messages"]["template"]
+    assert tmpl[0]["role"] == "system"
+    assert ds["sampling_params"] == {"temperature": 0.3}
+    assert ds["response_format"]["json_schema"]["name"] == "EvaluateResult"


### PR DESCRIPTION
## Summary
- document running evaluations with the OpenAI Evals API
- script to upload datasets and start OpenAI eval runs using system prompts, schema validation, and temperature controls
- test coverage for the enhanced OpenAI eval runner

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eaab093f0832c9fbe44ce7722ecaf