### PR TITLE
Refactor trace ID storage to include chat ID and fix prompt tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ forward those containing any of the specified words to their target chats.
 Statistics about processed messages are stored in `data/stats.json`. If you
 have a file in the old format (without the `stats` section), it will be
 automatically converted on startup using the new `Stats` structure. Trace IDs
-for forwarded messages are saved in `data/trace_ids.json`.
+for forwarded messages are saved in `data/trace_ids.json`, grouped by chat ID.
 
 ## Generate evaluation datasets
 

--- a/src/app.py
+++ b/src/app.py
@@ -154,7 +154,7 @@ async def process_message(inst: Instance, event: events.NewMessage.Event) -> Non
                     await client.send_message(dest, text)
                 forwarded = await message.forward_to(dest)
                 if forwarded and used_trace_id:
-                    trace_ids.set(forwarded.id, used_trace_id)
+                    trace_ids.set(forwarded.chat_id, forwarded.id, used_trace_id)
                 f_url = get_message_url(forwarded) if forwarded else None
                 logger.info(
                     "Forwarded message %s from %s to %s for %s (target url: %s)",
@@ -221,10 +221,10 @@ async def handle_reaction(update: "types.UpdateMessageReactions") -> None:
         message = await client.get_messages(update.peer, ids=update.msg_id)
         if not message:
             return
-        trace_id = trace_ids.get(message.id)
+        trace_id = trace_ids.get(peer_id, message.id)
         forwarded = await message.forward_to(dest)
         if forwarded and trace_id:
-            trace_ids.set(forwarded.id, trace_id)
+            trace_ids.set(forwarded.chat_id, forwarded.id, trace_id)
         if positive:
             forwarded_positive.add(key)
         elif negative:

--- a/src/generate_evals.py
+++ b/src/generate_evals.py
@@ -55,7 +55,7 @@ async def generate_evals(suffix: str) -> None:
                             {
                                 "input": text,
                                 "expected": {"is_match": True},
-                                "trace_id": trace_ids.get(msg.id),
+                                "trace_id": trace_ids.get(msg.chat_id, msg.id),
                             },
                             ensure_ascii=False,
                         )
@@ -72,7 +72,7 @@ async def generate_evals(suffix: str) -> None:
                             {
                                 "input": text,
                                 "expected": {"is_match": False},
-                                "trace_id": trace_ids.get(msg.id),
+                                "trace_id": trace_ids.get(msg.chat_id, msg.id),
                             },
                             ensure_ascii=False,
                         )

--- a/tests/test_generate_evals.py
+++ b/tests/test_generate_evals.py
@@ -10,8 +10,9 @@ from src.trace_ids import trace_ids
 
 
 class DummyMessage:
-    def __init__(self, msg_id: int, text: str):
+    def __init__(self, msg_id: int, text: str, chat_id: int):
         self.id = msg_id
+        self.chat_id = chat_id
         self.text = text
         self.message = text
         self.raw_text = text
@@ -63,11 +64,11 @@ async def test_generate_evals(tmp_path, monkeypatch):
     cfg_path.write_text(yaml.dump(cfg), encoding="utf-8")
 
     msgs = {
-        "pos": [DummyMessage(1, "p1"), DummyMessage(2, "p2")],
-        "neg": [DummyMessage(3, "n1")],
+        "pos": [DummyMessage(1, "p1", 100), DummyMessage(2, "p2", 100)],
+        "neg": [DummyMessage(3, "n1", 200)],
     }
     for m in msgs["pos"] + msgs["neg"]:
-        trace_ids.set(m.id, f"t{m.id}")
+        trace_ids.set(m.chat_id, m.id, f"t{m.id}")
     monkeypatch.setattr(ge, "TelegramClient", lambda *a, **k: DummyClient(msgs))
 
     await ge.generate_evals("suf")

--- a/tests/test_langfuse.py
+++ b/tests/test_langfuse.py
@@ -20,6 +20,9 @@ class DummyLangfuse:
     def update_current_generation(self, **kwargs):  # noqa: D401 - test stub
         self.generations.append(kwargs)
 
+    def get_current_trace_id(self):  # noqa: D401 - test stub
+        return "tid"
+
 
 def test_init_langfuse(monkeypatch):
     recorded = {}
@@ -71,7 +74,9 @@ async def test_match_prompt_logs(monkeypatch):
     prompt = prompts.Prompt(name="p", prompt="p")
     res = await prompts.match_prompt(prompt, "text", "i", "c")
 
-    assert res == result_obj
+    assert res == prompts.MatchPromptResult(
+        score=4, reasoning="", quote="f", trace_id="tid"
+    )
     assert dummy.traces[0]["name"] == "p"
     assert dummy.traces[0]["input"] == "text"
     assert dummy.traces[0]["output"] == result_obj.model_dump()
@@ -191,7 +196,9 @@ async def test_match_prompt_lf_config(monkeypatch):
 
     res = await prompts.match_prompt(p, "text")
 
-    assert res == result_obj
+    assert res == prompts.MatchPromptResult(
+        score=3, reasoning="", quote="f", trace_id="tid"
+    )
     assert recorded["temperature"] == 0.1
     # generation logging was removed
     assert dummy.generations == []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -208,7 +208,9 @@ async def test_match_prompt_no_api(monkeypatch):
     prompts.config["openai_api_key"] = ""
     prompt = prompts.Prompt(name="n", prompt="hello")
     result = await prompts.match_prompt(prompt, "msg")
-    assert result == prompts.EvaluateResult(score=0, reasoning="", quote="")
+    assert result == prompts.MatchPromptResult(
+        score=0, reasoning="", quote="", trace_id=None
+    )
 
 
 def test_get_forward_reason_text_word():

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -141,7 +141,7 @@ async def test_process_message_prompt(monkeypatch, dummy_message_cls, tmp_path):
         assert prompt.prompt == "hi"
         assert inst_name == "p"
         assert chat_name == "n"
-        return prompts.EvaluateResult(score=5, reasoning="", quote="")
+        return prompts.MatchPromptResult(score=5, reasoning="", quote="", trace_id=None)
 
     async def fake_get_message_source(msg):
         return "src"

--- a/tests/test_trace_ids.py
+++ b/tests/test_trace_ids.py
@@ -7,7 +7,7 @@ from src.trace_ids import TraceStore
 def test_trace_store(tmp_path):
     path = tmp_path / "trace_ids.json"
     store = TraceStore(str(path), flush_interval=0)
-    store.set(123, "abc")
-    assert json.loads(path.read_text(encoding="utf-8")) == {"123": "abc"}
+    store.set(1, 123, "abc")
+    assert json.loads(path.read_text(encoding="utf-8")) == {"1": {"123": "abc"}}
     new_store = TraceStore(str(path))
-    assert new_store.get(123) == "abc"
+    assert new_store.get(1, 123) == "abc"


### PR DESCRIPTION
## Summary
- track trace IDs per chat/message pair
- adjust app and eval utilities for new trace ID API
- update prompt tests for `MatchPromptResult`

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f94e0cb20832cb54ea2799683da9f