### PR TITLE
Track forwarded stats at all levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,13 @@ python -m src.main
 The application will listen to new messages in all configured instances and
 forward those containing any of the specified words to their target chats.
 
-Statistics about processed messages are stored in `data/stats.json`. If you
-have a file in the old format (without the `stats` section), it will be
-automatically converted on startup using the new `Stats` structure. Trace IDs
-for forwarded messages are saved in `data/trace_ids.json`, grouped by chat ID.
+Statistics about processed messages are stored in `data/stats.json` and include
+overall, per-instance and per-day counters. Besides the total processed
+messages, the file tracks how many were forwarded in total, due to word matches
+or prompt matches, and the number of tokens consumed. If you have a file in the
+old format (without the `stats` section), it will be automatically converted on
+startup using the new `Stats` structure. Trace IDs for forwarded messages are
+saved in `data/trace_ids.json`, grouped by chat ID.
 
 ## Generate evaluation datasets
 

--- a/src/app.py
+++ b/src/app.py
@@ -101,7 +101,6 @@ async def process_message(inst: Instance, event: events.NewMessage.Event) -> Non
             inst.name,
         )
         return
-    stats.increment(inst.name)
     chat_name = await get_chat_name(event.chat_id, safe=True)
     forward = False
     used_word: str | None = None
@@ -173,6 +172,12 @@ async def process_message(inst: Instance, event: events.NewMessage.Event) -> Non
             chat_name,
             inst.name,
         )
+    stats.increment(
+        inst.name,
+        forwarded=forward,
+        used_word=used_word is not None,
+        used_prompt=used_prompt is not None,
+    )
 
 
 async def handle_reaction(update: "types.UpdateMessageReactions") -> None:

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -111,9 +111,13 @@ async def test_main_flow(monkeypatch, dummy_tg_client, dummy_message_cls, tmp_pa
     assert dummy_client.sent[1][0][0] == "name"
     data = json.loads(stats_path.read_text())
     assert data["stats"]["total"] == 1
+    assert data["stats"]["forwarded_total"] == 1
+    assert data["stats"]["forwarded_words"] == 1
     inst = data["instances"][0]
     assert inst["name"] == "i"
     assert inst["stats"]["total"] == 1
+    assert inst["stats"]["forwarded_total"] == 1
+    assert inst["stats"]["forwarded_words"] == 1
 
 
 @pytest.mark.asyncio
@@ -160,6 +164,11 @@ async def test_process_message_prompt(monkeypatch, dummy_message_cls, tmp_path):
 
     assert sent[0][0][0] == 1
     assert msg.forwarded == [1]
+    assert app.stats.data["stats"]["forwarded_total"] == 1
+    assert app.stats.data["stats"]["forwarded_prompt"] == 1
+    inst_data = app.stats.data["instances"][0]
+    assert inst_data["stats"]["forwarded_total"] == 1
+    assert inst_data["stats"]["forwarded_prompt"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -6,8 +6,8 @@ import src.stats as stats_module
 def test_stats_increment_and_flush(tmp_path):
     path = tmp_path / "stats.json"
     tracker = stats_module.StatsTracker(str(path), flush_interval=0)
-    tracker.increment("a")
-    tracker.increment("a")
+    tracker.increment("a", forwarded=True, used_word=True)
+    tracker.increment("a", forwarded=True, used_prompt=True)
     tracker.increment("b")
     tracker.add_tokens("a", 10)
     tracker.add_tokens("b", 5)
@@ -15,14 +15,23 @@ def test_stats_increment_and_flush(tmp_path):
     data = json.loads(path.read_text())
     assert data["stats"]["total"] == 3
     assert data["stats"]["tokens"] == 15
+    assert data["stats"]["forwarded_total"] == 2
+    assert data["stats"]["forwarded_words"] == 1
+    assert data["stats"]["forwarded_prompt"] == 1
     inst_a = next(i for i in data["instances"] if i["name"] == "a")
     inst_b = next(i for i in data["instances"] if i["name"] == "b")
     assert inst_a["stats"]["total"] == 2
     assert inst_b["stats"]["total"] == 1
     assert inst_a["stats"]["tokens"] == 10
     assert inst_b["stats"]["tokens"] == 5
+    assert inst_a["stats"]["forwarded_total"] == 2
+    assert inst_a["stats"]["forwarded_words"] == 1
+    assert inst_a["stats"]["forwarded_prompt"] == 1
     day = list(inst_a["days"].keys())[0]
     assert inst_a["days"][day]["stats"]["total"] == 2
+    assert inst_a["days"][day]["stats"]["forwarded_total"] == 2
+    assert inst_a["days"][day]["stats"]["forwarded_words"] == 1
+    assert inst_a["days"][day]["stats"]["forwarded_prompt"] == 1
 
 
 def test_convert_old_format():


### PR DESCRIPTION
## Summary
- add `current_day` helper to stats module
- count forwarded messages, words and prompts for root, instance and day
- update message processing to record detailed forwarding stats

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f99561ec0832c9eee5516dda1c26c