### PR TITLE
feat: allow custom config in eval generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Build evaluation tasks from collected true and false positive messages:
 python -m src.generate_evals --suffix run1
 ```
 
+Use `--config` to provide a custom path to `config.yml` if needed.
+
 Datasets and configuration files will be written to `data/evals/` with the
 provided suffix. Each line in `messages.jsonl` also contains a `trace_id`
 linking back to the corresponding Langfuse trace.

--- a/tests/test_generate_evals.py
+++ b/tests/test_generate_evals.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-import src.config as config_module
 import src.generate_evals as ge
 from src.trace_ids import trace_ids
 
@@ -38,7 +37,6 @@ async def test_generate_evals(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     cfg_path = tmp_path / "config.yml"
-    monkeypatch.setattr(config_module, "CONFIG_PATH", cfg_path)
 
     cfg = {
         "api_id": 1,
@@ -71,7 +69,7 @@ async def test_generate_evals(tmp_path, monkeypatch):
         trace_ids.set(m.chat_id, m.id, f"t{m.id}")
     monkeypatch.setattr(ge, "TelegramClient", lambda *a, **k: DummyClient(msgs))
 
-    await ge.generate_evals("suf")
+    await ge.generate_evals("suf", config_path=str(cfg_path))
 
     base = Path("data/evals/Inst_Prompt_suf")
     data = base / "messages.jsonl"


### PR DESCRIPTION
## Summary
- allow passing a config path in generate_evals and expose it via `--config`
- document config option for generate_evals
- adapt generate_evals tests for custom config path

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fb4794704832ca2f0fcf0a82c1fa4