### PR TITLE
Track daily token usage in stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ forward those containing any of the specified words to their target chats.
 Statistics about processed messages are stored in `data/stats.json` and include
 overall, per-instance and per-day counters. Besides the total processed
 messages, the file tracks how many were forwarded in total, due to word matches
-or prompt matches, and the number of tokens consumed. If you have a file in the
-old format (without the `stats` section), it will be automatically converted on
-startup using the new `Stats` structure. Trace IDs for forwarded messages are
-saved in `data/trace_ids.json`, grouped by chat ID.
+or prompt matches, and the number of tokens consumed in each scope. If you have
+a file in the old format (without the `stats` section), it will be automatically
+converted on startup using the new `Stats` structure. Trace IDs for forwarded
+messages are saved in `data/trace_ids.json`, grouped by chat ID.
 
 ## Generate evaluation datasets
 

--- a/src/stats.py
+++ b/src/stats.py
@@ -127,8 +127,10 @@ class StatsTracker:
         if tokens <= 0:
             return
         inst = self._get_inst(name)
-        self.data["stats"]["tokens"] = self.data["stats"].get("tokens", 0) + tokens
-        inst["stats"]["tokens"] = inst["stats"].get("tokens", 0) + tokens
+        day = current_day()
+        day_stat = inst["days"].setdefault(day, {"stats": Stats().to_dict()})
+        for scope in (self.data["stats"], inst["stats"], day_stat["stats"]):
+            scope["tokens"] = scope.get("tokens", 0) + tokens
         inst["tokens"] = inst.get("tokens", 0) + tokens
         self.dirty = True
         if time.monotonic() - self.last_flush >= self.flush_interval:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -32,6 +32,7 @@ def test_stats_increment_and_flush(tmp_path):
     assert inst_a["days"][day]["stats"]["forwarded_total"] == 2
     assert inst_a["days"][day]["stats"]["forwarded_words"] == 1
     assert inst_a["days"][day]["stats"]["forwarded_prompt"] == 1
+    assert inst_a["days"][day]["stats"]["tokens"] == 10
 
 
 def test_convert_old_format():


### PR DESCRIPTION
## Summary
- track token counts at day, instance, and root levels
- document per-scope token tracking
- test daily token accounting

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68909d05209c832c82bb0bba33507aa2