### PR TITLE
Add folder topic creation from folder configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ matching messages to a target chat.
 - Prompt-triggered forwards include a short reason and quote from the message
 - Reactions (👍/👎) forward messages to true/false positive chats once per message
 - Langfuse trace IDs for forwarded messages are recorded
+- Automatically create forum topics for chats collected from folders
 
 ## Setup
 
@@ -37,8 +38,12 @@ pip install -r requirements.txt
 - `ignore_user_ids` – list of user IDs to ignore when processing messages.
 - `instances` – list of monitoring instances. Each instance may contain
   `folders`, `chat_ids`, `entities`, `words`, `negative_words`, `ignore_words`, `target_chat`,
-  `target_entity`, `folder_mute`, `false_positive_entity`, `true_positive_entity` and
-  `no_forward_message`.
+  `target_entity`, `folder_mute`, `folder_add_topic`, `false_positive_entity`, `true_positive_entity`
+  and `no_forward_message`.
+
+`folder_add_topic` is a list of topics that should exist in every chat inside the
+instance folders. When a topic is missing, the bot will create it and send an
+optional activation message inside the new thread.
 
 ## Running
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -14,6 +14,9 @@ instances:
     entities:
       - https://t.me/tboom_66
     folders: []
+    folder_add_topic:
+      - name: Community Updates
+        message: "/activate@example_updates_bot"
     folder_mute: false
     no_forward_message: false
     words: ["my username"]

--- a/src/app.py
+++ b/src/app.py
@@ -9,6 +9,7 @@ from .config import Instance, get_api_credentials, load_config, load_instances
 from .prompts import Prompt, match_prompt
 from .stats import stats as global_stats
 from .telegram_utils import (
+    add_topic_from_folders,
     find_word,
     get_chat_name,
     get_folders_chat_ids,
@@ -63,6 +64,8 @@ async def update_instance_chat_ids(instance: Instance, first_run: bool = False) 
     instance.chat_ids = await normalize_chat_ids(new_ids)
     if instance.folder_mute:
         await mute_chats_from_folders(instance.folders)
+    if instance.folder_add_topic:
+        await add_topic_from_folders(instance.folders, instance.folder_add_topic)
     log_level = logging.INFO if first_run else logging.DEBUG
     logger.log(
         log_level,

--- a/src/telegram_utils.py
+++ b/src/telegram_utils.py
@@ -375,15 +375,14 @@ async def add_topic_from_folders(
                 if not created:
                     continue
                 topic_id = getattr(created, "id", None)
-                if topic.message and topic_id is not None:
+                top_msg_id = getattr(created, "top_message", None)
+                thread_id = top_msg_id if top_msg_id is not None else topic_id
+                if topic.message and thread_id is not None:
                     try:
                         await client.send_message(
                             channel,
                             topic.message,
-                            reply_to=types.InputReplyToMessage(
-                                reply_to_msg_id=topic_id,
-                                top_msg_id=topic_id,
-                            ),
+                            reply_to=thread_id,
                         )
                     except Exception as exc:  # pylint: disable=broad-except
                         logger.error(
@@ -392,11 +391,11 @@ async def add_topic_from_folders(
                             chat_id,
                             exc,
                         )
-                added.append((chat_id, topic_id, chat_title))
+                added.append((chat_id, thread_id, chat_title))
                 logger.info(
                     "Added topic to chat %s thread %s (%s)",
                     chat_id,
-                    topic_id,
+                    thread_id,
                     chat_title,
                 )
     return added

--- a/src/telegram_utils.py
+++ b/src/telegram_utils.py
@@ -379,6 +379,7 @@ async def add_topic_from_folders(
                 thread_id = top_msg_id if top_msg_id is not None else topic_id
                 if topic.message and thread_id is not None:
                     try:
+                        await asyncio.sleep(2)
                         await client.send_message(
                             channel,
                             topic.message,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,3 +35,22 @@ def test_config_path_env_override(tmp_path, monkeypatch):
     cfg_module = importlib.reload(config)
     assert cfg_module.CONFIG_PATH == str(cfg)
     assert cfg_module.load_config() == {"bar": 2}
+
+
+@pytest.mark.asyncio
+async def test_load_instances_folder_add_topic():
+    cfg = {
+        "instances": [
+            {
+                "name": "inst",
+                "words": [],
+                "folder_add_topic": [{"name": "Topic", "message": "hello"}],
+            }
+        ]
+    }
+
+    instances = await config.load_instances(cfg)
+    assert instances[0].folder_add_topic
+    topic = instances[0].folder_add_topic[0]
+    assert topic.name == "Topic"
+    assert topic.message == "hello"

--- a/tests/test_folders.py
+++ b/tests/test_folders.py
@@ -200,6 +200,13 @@ async def test_add_topic_from_folders(monkeypatch, caplog):
     dummy_client = DummyClient()
     monkeypatch.setattr(tgu, "client", dummy_client)
 
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(tgu.asyncio, "sleep", fake_sleep)
+
     folder = SimpleNamespace(title="Folder", include_peers=[SimpleNamespace(id=1)])
 
     async def fake_list_folders():
@@ -215,4 +222,5 @@ async def test_add_topic_from_folders(monkeypatch, caplog):
     _, sent_message, kwargs = dummy_client.sent[0]
     assert sent_message == "hello"
     assert kwargs.get("reply_to") == 101
+    assert sleep_calls == [2]
     assert any("chat 123 thread 101" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add a `folder_add_topic` option to instance configuration and parse it into `FolderTopic`
- create forum topics for chats from configured folders and optionally post activation messages
- document the new option and cover it with tests for both config parsing and forum topic creation

## Testing
- pytest
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68cd3837439c832c95dba39aa93911e4