### PR TITLE
feat(skills): interactive config.yml instance wizard

### DIFF
--- a/.claude/skills/telegram-resender
+++ b/.claude/skills/telegram-resender
@@ -1,0 +1,1 @@
+../../skills/telegram-resender

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ This project forwards Telegram messages that match specific rules to a target ch
 │   └── __init__.py       # marks package
 ├── scripts/
 │   └── test_webhook_server.py  # manual webhook listener (port 8002)
+├── skills/
+│   └── telegram-resender/ # interactive config.yml instance wizard (SKILL.md + instance-options.md)
+│                          # symlinked from .claude/skills/telegram-resender for discovery
 ├── tests/                # pytest suite
 ├── README.md             # setup instructions
 ├── CHANGELOG.md          # generated from conventional commits by git-cliff

--- a/docs/superpowers/specs/2026-07-04-telegram-resender-skill-design.md
+++ b/docs/superpowers/specs/2026-07-04-telegram-resender-skill-design.md
@@ -1,0 +1,123 @@
+# Design: `telegram-resender` config-management skill
+
+**Date:** 2026-07-04
+**Status:** Approved (design)
+
+## Purpose
+
+An agent skill that manages this project's `data/config.yml` — specifically the
+`instances` list — through a step-by-step interview. It:
+
+1. Adds a new monitoring instance via `AskUserQuestion`, asking essentials first
+   and offering advanced options.
+2. Edits or removes existing instances.
+3. Explains what any instance config option means or does.
+
+The skill is instructions for the agent (Claude), not a runtime feature of the
+bot. The agent reads/edits `data/config.yml` with its own file tools and
+validates using the project's own config loader.
+
+## Type & location
+
+- **Type:** technique (interactive wizard) + reference (per-option docs).
+- **Repo-tracked source of truth:** `skills/telegram-resender/`.
+- **Discovery:** Claude Code auto-discovers skills only under `.claude/skills/`,
+  not a bare repo-root `skills/`. A committed symlink bridges them. `.claude/`
+  is **not** gitignored in this repo, so the symlink commits without any
+  gitignore change.
+
+```
+skills/telegram-resender/
+  SKILL.md              # wizard flow + validation + quick-reference table
+  instance-options.md   # full per-option reference (heavy reference, kept out of SKILL.md)
+.claude/skills/telegram-resender -> ../../skills/telegram-resender   # committed discovery symlink
+```
+
+## Frontmatter
+
+- `name: telegram-resender`
+- `description` (triggering conditions only, per SDO — no workflow summary):
+  > Use when adding, editing, or removing a monitoring instance in the
+  > telegram-resender `data/config.yml`, or when the user asks what an instance
+  > config option means or does.
+
+## SKILL.md flow
+
+1. **Locate & read** `data/config.yml` (honor the `CONFIG_PATH` env override,
+   matching `src/config.py`). List existing instance names for the user.
+2. **Branch:** add / edit / remove / explain-an-option.
+3. **Add-instance wizard** (`AskUserQuestion`, essentials first):
+   - **Round A — identity + sources:** `name`; sources via `entities`
+     (t.me links) and/or `folders`.
+   - **Round B — matching:** `words` (trigger terms), `negative_words`,
+     `ignore_words`; explain the AND/OR semantics.
+   - **Round C — target:** at least one of `target_chat` / `target_entity` /
+     `target_webhook`.
+   - **Then one question:** "Configure advanced options?" — if yes, grouped
+     rounds for:
+     - forwarding behavior: `once_per_chat` (+`reset_hour`), `debounce_ms`
+       (+`cancel_on_owner_reply`)
+     - message preface: `no_forward_message` / `message_template` /
+       `forward_message` flags (`show_trigger`, `show_source`, `prefix`,
+       `suffix`)
+     - AI `prompts` (`name`, `prompt`, `threshold`, optional Langfuse keys)
+     - folder automation: `folder_mute`, `folder_add_topic`
+     - misc: `ignore_usernames_override`, `false_positive_entity`,
+       `true_positive_entity`, `chat_ids`
+4. **Edit-instance flow:** pick instance → pick field(s) → new value →
+   surgical Edit.
+5. **Remove-instance flow:** pick instance → confirm → delete its YAML block.
+6. **Write back** via the Edit tool (not a YAML round-trip) to preserve
+   comments and ordering. A new instance is appended in the block style of
+   `config-example.yml`. This avoids adding a `ruamel.yaml` dependency.
+7. **Validate** with the project's own loader, no bot restart:
+   ```
+   python -c "import asyncio; from src.config import load_config, load_instances; asyncio.run(load_instances(load_config()))"
+   ```
+   Reports nothing on success; raises on validation error. On failure, fix or
+   revert. Tell the user to restart the bot themselves.
+
+## instance-options.md
+
+One entry per instance option, mirroring `src/config.py`:
+
+- key, type, default, required?
+- validation rules (e.g. `reset_hour` 0–23; `debounce_ms` ≥ 0 int;
+  `target_webhook.format` ∈ {text, json}; `message_template` placeholders
+  `{trigger} {source} {username} {name} {chat}`; `forward_message.*` types;
+  `cancel_on_owner_reply` bool)
+- what it does
+- an example value
+- the wizard question to ask for it
+
+This satisfies the "describe each config option" requirement and is the source
+the "explain-an-option" branch reads from.
+
+## Validation & apply decisions (locked)
+
+- Edit in place, preserve comments.
+- Validate by loading via `load_instances`; do **not** restart the bot.
+- Wizard: essentials, then offer advanced.
+
+## Build method
+
+Built TDD-style per the `writing-skills` skill, adapted for a
+technique/reference skill:
+
+1. **RED (baseline):** dispatch a subagent to add and edit an instance
+   *without* the skill; record what it gets wrong (invalid values, missed
+   validation, unknown/omitted options).
+2. **GREEN:** write `SKILL.md` + `instance-options.md` addressing those gaps;
+   verify a subagent can add an instance, edit one, and correctly explain an
+   option using the skill.
+3. **REFACTOR:** close gaps found in testing; re-verify.
+
+Then create the committed symlink and validate discovery.
+
+## Out of scope
+
+- Managing top-level config keys (`api_id`, `openai_*`, `langfuse_*`, `proxy_url`)
+  beyond what an instance needs. The skill focuses on `instances`.
+- Restarting or deploying the bot.
+- Runtime changes to the bot itself (project repo is read-only per README;
+  this skill only edits `data/config.yml` and adds skill files).

--- a/skills/telegram-resender/SKILL.md
+++ b/skills/telegram-resender/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: telegram-resender
+description: Use when adding, editing, or removing a monitoring instance in the telegram-resender data/config.yml, or when the user asks what an instance config option (words, folders, target_chat, debounce_ms, once_per_chat, prompts/threshold, message_template, forward_message, target_webhook) means or does.
+---
+
+# telegram-resender config
+
+Manage the `instances:` list in this project's `data/config.yml` through a
+step-by-step interview, then validate the result with the project's own loader.
+
+An **instance** is one set of rules: watch some Telegram sources, match messages,
+forward matches to a target. Every option is documented in
+[instance-options.md](instance-options.md) — that file is the source of truth for
+types, defaults, validation, and the question to ask. Read it before asking about
+or writing any option you are unsure of.
+
+## The one rule: ask, don't guess
+
+Values like the instance `name`, the trigger `words`, the `target_chat`, and
+especially prompt text and `threshold` are the user's to decide. **Never invent
+them.** Use `AskUserQuestion` for every field whose value you do not already have
+from the user. A plausible guess that parses is still wrong.
+
+## Flow
+
+1. **Locate & read** `data/config.yml` (respect the `CONFIG_PATH` env var, same as
+   `src/config.py`). If it is missing, tell the user and stop. List the existing
+   instance `name`s.
+2. **Branch** on intent: add / edit / remove / explain-an-option.
+3. Do the branch below.
+4. **Validate** (always, after any write — see Validate).
+
+### Add an instance (wizard)
+
+Ask **essentials first**, one `AskUserQuestion` round per group. Consult
+instance-options.md for each option's meaning and allowed values.
+
+- **Round A — identity + sources:** `name` (must be unique); at least one source —
+  `entities` (t.me links / @usernames), `folders` (folder names), or `chat_ids`.
+- **Round B — matching:** `words` (trigger terms), `negative_words`, `ignore_words`.
+  Explain the semantics below.
+- **Round C — target:** at least one of `target_chat`, `target_entity`,
+  `target_webhook`.
+- **Then ask once:** "Configure advanced options?" If yes, run grouped rounds only
+  for the areas the user wants:
+  - forwarding *when*: `once_per_chat` (+`reset_hour`), `debounce_ms`
+    (+`cancel_on_owner_reply`)
+  - forwarded-message preface: `no_forward_message` / `message_template` /
+    `forward_message` (`show_trigger`, `show_source`, `prefix`, `suffix`)
+  - AI scoring: `prompts` (`name`, `prompt`, `threshold`, optional Langfuse keys)
+  - folder automation: `folder_mute`, `folder_add_topic`
+  - misc: `ignore_usernames_override`, `false_positive_entity`,
+    `true_positive_entity`
+
+### Edit an instance
+
+List instances, let the user pick one and the field(s) to change, confirm the new
+value against instance-options.md validation, then apply a surgical Edit.
+
+### Remove an instance
+
+Let the user pick, show the block, confirm, delete only that block.
+
+### Explain an option
+
+Answer from instance-options.md. Do not read source unless the reference lacks it.
+
+## Matching semantics — state these, they surprise people
+
+`ignore_words` and `negative_words` both **suppress** the message entirely if any
+term appears (they are checked before matching). Same effect; use `ignore_words`
+for noise, `negative_words` for "not this kind of match."
+
+`words` and `prompts` are **OR with word-priority, never AND**: if any `word`
+matches, the message forwards immediately and **the prompts never run**. Prompts
+run **only when no word matched**. So you cannot express "keyword AND high AI
+score" in config — if a user asks for that gating, tell them it is a code change,
+not a config option.
+
+`threshold` (default 4) forwards when the model's returned score is `>=` it. The
+scale is whatever your prompt text tells the model to use — define the scale in
+the prompt so the threshold has meaning.
+
+## Write-back rules
+
+- Edit `data/config.yml` **in place with the Edit tool** — do not round-trip
+  through a YAML dumper (it would strip comments and reorder keys).
+- Match the surrounding indentation and the block style in `config-example.yml`.
+- Omit options left at their default rather than writing every key.
+
+## Validate
+
+After every write, run the project's own loader from the repo root (no bot
+restart — tell the user to restart the bot themselves):
+
+```
+.venv/bin/python -c "import asyncio; from src.config import load_config, load_instances; asyncio.run(load_instances(load_config()))"
+```
+
+Silent exit = valid. A traceback = invalid: read the `ValueError`, fix the config
+(or revert your edit), and re-run until it passes.
+
+## Common mistakes
+
+| Mistake | Reality |
+|---------|---------|
+| Guessing a name, word, prompt text, or threshold | Ask the user. These are theirs to decide. |
+| Configuring "keyword AND AI score" | Code treats them as OR/fallback. Not possible in config. |
+| Assuming a fixed 1–10 prompt scale | The scale lives in the prompt text; set it there, then pick a matching threshold. |
+| Writing every key at its default | Omit defaults; keep the block readable. |
+| Round-tripping the YAML through a dumper | Strips comments/order. Use surgical Edits. |
+| Skipping validation | Always run the loader; a typo silently breaks the next bot start. |

--- a/skills/telegram-resender/instance-options.md
+++ b/skills/telegram-resender/instance-options.md
@@ -1,0 +1,176 @@
+# Instance options reference
+
+Every key allowed under one entry of `instances:` in `data/config.yml`. Types,
+defaults, and validation mirror `src/config.py` (`load_instances`) and the
+matching logic in `src/app.py`. For each option: what it does, the value to
+write, and the question to ask the user.
+
+Only `name` is truly required; give an instance at least one **source** and one
+**target** or it does nothing. Omit any option to accept its default.
+
+## Identity
+
+### `name`
+- **Type:** string. **Default:** `"instance"`. **Effectively required** — must be
+  unique across instances (used as the key in `data/seen_chats.json` and stats).
+- **Ask:** "Name for this instance?"
+
+## Sources — where to watch (need at least one)
+
+### `entities`
+- **Type:** list of strings (t.me links or `@username`). **Default:** `[]`.
+- Specific chats/channels to monitor.
+- **Ask:** "Which specific chats/channels? (t.me links or @usernames)"
+
+### `folders`
+- **Type:** list of strings (Telegram folder names). **Default:** `[]`.
+- Monitors every chat currently in the named folders; re-resolved on startup and
+  folder rescans. Pairs well with `once_per_chat`.
+- **Ask:** "Which Telegram folders (by name)?"
+
+### `chat_ids`
+- **Type:** list of integers. **Default:** `[]` (stored as a set). Negative IDs are
+  normal for groups/channels (e.g. `-1001234567890`).
+- Numeric chat IDs to monitor, as an alternative to `entities`.
+- **Ask:** "Any raw numeric chat IDs to watch?"
+
+## Matching — which messages count
+
+> `ignore_words` and `negative_words` are checked **first** and **suppress** the
+> message entirely if any term appears. `words` and `prompts` are **OR with
+> word-priority**: a `words` hit forwards immediately and prompts never run;
+> prompts run only when no word matched. There is no keyword-AND-prompt gating.
+
+### `words`
+- **Type:** list of strings. **Default:** `[]`. Substring match, case-insensitive.
+- The trigger terms. Any one match forwards the message.
+- **Ask:** "Which words/phrases should trigger a forward?"
+
+### `negative_words`
+- **Type:** list of strings. **Default:** `[]`.
+- If any appears, the message is **skipped** (never forwarded). Use for "matches a
+  word but is the wrong kind of match."
+- **Ask:** "Any words that should cancel a match?"
+
+### `ignore_words`
+- **Type:** list of strings. **Default:** `[]`.
+- Same suppression effect as `negative_words` (checked one step earlier). Convention
+  only: use for noise/spam terms.
+- **Ask:** "Any words that mark a message as noise to ignore?"
+
+### `prompts`
+- **Type:** list of prompt objects. **Default:** `[]`. Run **only when no `word`
+  matched**. Each is scored by the LLM; the message forwards if any prompt's score
+  `>= threshold`.
+- Prompt object keys:
+  - `name` — string label (used in stats/traces).
+  - `prompt` — the instruction text sent to the model. **Define the scoring scale
+    here** (e.g. "score 1–10 …") so the threshold is meaningful.
+  - `threshold` — integer, **default `4`**. Forwards when the returned score `>=`
+    this. There is no fixed scale — it matches whatever the prompt text says.
+  - Optional Langfuse keys: `langfuse_name`, `langfuse_label` (default `"latest"`),
+    `langfuse_version`, `langfuse_type` (default `"text"`), and `config` (a mapping
+    like `{model: gpt-4o, temperature: 0.7}`).
+- **Ask:** "Describe what the AI should score for, the scale to use, and the
+  cutoff." Never invent the prompt text or threshold.
+
+## Target — where matches go (need at least one)
+
+### `target_chat`
+- **Type:** integer chat ID. **Default:** `null`.
+- **Ask:** "Numeric chat ID to forward matches to?"
+
+### `target_entity`
+- **Type:** string (t.me link / `@username`). **Default:** `""`.
+- Alternative to `target_chat` by name.
+- **Ask:** "Or a chat by @username / t.me link?"
+
+### `target_webhook`
+- **Type:** mapping. **Default:** none. Runs **alongside** the Telegram target, not
+  instead of it. Failures are logged and swallowed (10s timeout).
+  - `url` — **required** when the block is present.
+  - `format` — `"text"` (default) or `"json"`. Any other value is rejected at load.
+    `text` = one line; `json` = object with `from_username`, `from_name`,
+    `message_text`, `chat_id`, `message_id`, `message_url`, `timestamp`.
+- **Ask:** "POST matches to an HTTP endpoint too? URL and format (text/json)?"
+
+## Forwarding behavior — when to forward
+
+### `once_per_chat`
+- **Type:** bool. **Default:** `false`. Forward only the **first** match per chat
+  per day, then suppress until the reset hour. State in `data/seen_chats.json`
+  survives restarts.
+- **Ask:** "Forward only the first match per chat each day?"
+
+### `reset_hour`
+- **Type:** integer **0–23** (out of range is rejected). **Default:** `6`. Local
+  hour each chat re-arms. Ignored when `once_per_chat` is false.
+- **Ask:** "What hour (0–23) should the daily limit reset?"
+
+### `debounce_ms`
+- **Type:** integer `>= 0` (negative is rejected). **Default:** `0` (forward
+  immediately). When `> 0`, buffers per-chat messages and forwards the whole batch
+  after that many ms of silence; every new message resets the timer. Buffers are
+  in-memory (lost on restart).
+- **Ask:** "Batch a burst of messages before forwarding? Silence window in ms?"
+
+### `cancel_on_owner_reply`
+- **Type:** bool. **Default:** `true`. Only matters when `debounce_ms > 0`. If an
+  ignored username (account owner) posts during the window, the batch is dropped
+  and nothing forwards. Set `false` to always deliver.
+- **Ask:** "If you reply during a batch window, cancel that batch?"
+
+## Forwarded-message preface
+
+Precedence: `no_forward_message` → `message_template` → `forward_message` flags.
+
+### `no_forward_message`
+- **Type:** bool. **Default:** `false`. Suppresses the preface entirely; wins over
+  the two below.
+- **Ask:** "Send forwarded messages with no preface at all?"
+
+### `message_template`
+- **Type:** string or null. **Default:** `null`. Overrides the whole preface layout.
+  Placeholders (missing values render as `""`, never error): `{trigger}`,
+  `{source}`, `{username}`, `{name}`, `{chat}`. Malformed templates (unbalanced
+  braces, positional/attribute fields) are rejected at load.
+- **Ask:** "Custom preface template? Placeholders: {trigger} {source} {username}
+  {name} {chat}."
+
+### `forward_message`
+- **Type:** mapping (used only when `message_template` is absent). Keys, each
+  validated for type:
+  - `show_trigger` — bool, default `true` (include the match reason).
+  - `show_source` — bool, default `true` (include the `Forwarded from: …` line).
+  - `prefix` — string, default `""` (prepended).
+  - `suffix` — string, default `""` (appended).
+- **Ask:** "Toggle the match reason / source line, or add prefix/suffix text?"
+
+## Folder automation
+
+### `folder_mute`
+- **Type:** bool. **Default:** `false`. Mute the instance's folder chats.
+- **Ask:** "Mute the chats in these folders?"
+
+### `folder_add_topic`
+- **Type:** list of topic objects. **Default:** `[]`. Ensures each topic exists in
+  every folder chat; creates it if missing, sends an optional message in the new
+  thread, invites an optional user. Entries without `name` are skipped.
+  - `name` — **required** topic title.
+  - `message` — optional text sent into the created thread.
+  - `username` — optional user to invite to the chat.
+- **Ask:** "Auto-create any topics in the folder chats? (name, optional activation
+  message, optional user to invite)"
+
+## Misc
+
+### `ignore_usernames_override`
+- **Type:** list of strings, or omitted. **Default:** omitted (inherits the global
+  `ignore_usernames`). If set — even to `[]` — this instance uses this list instead;
+  `[]` means ignore nobody.
+- **Ask:** "Override the global ignored-usernames list for this instance?"
+
+### `false_positive_entity` / `true_positive_entity`
+- **Type:** string. **Default:** `""`. Chats where you drop messages to label them
+  as false/true positives, feeding eval-dataset generation.
+- **Ask:** "Chats to collect false/true-positive examples for evals?"


### PR DESCRIPTION
## Summary

Adds a repo-tracked agent skill, `telegram-resender`, that manages the `instances:` list in `data/config.yml` through a step-by-step `AskUserQuestion` interview — add, edit, remove, and explain instances — then validates via the project's own `load_instances`.

Built TDD-style (per the writing-skills process): a baseline agent without the skill produced valid YAML but *guessed* user-owned values (name, prompt text, threshold) and had to read `src/app.py` to discover the matching semantics. A verifier agent using only the skill answered all previously-failed questions correctly without touching `src/`.

## What's in the diff

- `skills/telegram-resender/SKILL.md` — wizard flow (add/edit/remove/explain), the "ask, don't guess" rule, matching-semantics warnings, write-back rules (surgical Edit, preserve comments), and the validation command.
- `skills/telegram-resender/instance-options.md` — every instance option documented: type, default, validation (mirrored from `src/config.py`), behavior, example, and the question to ask.
- `.claude/skills/telegram-resender` — committed symlink (mode `120000`) so Claude Code auto-discovers the skill.
- `AGENTS.md` — structure tree updated per project rule.
- `docs/superpowers/specs/2026-07-04-telegram-resender-skill-design.md` — approved design spec.

Documentation/tooling only — no runtime bot code changes.

## Key behaviors documented (previously required reading source)

- `words` and `prompts` are **OR with word-priority**, never AND — a word match forwards immediately and prompts never run.
- `negative_words` and `ignore_words` both suppress; distinction is convention.
- `threshold` scale is defined by the prompt text, not a fixed 1–10.

## Reviewer checklist (manual)

- [ ] `.claude/skills/telegram-resender` resolves and the skill is discoverable (`/telegram-resender` or a config request triggers it)
- [ ] Try "add a new instance to config.yml" — confirm it interviews rather than guesses
- [ ] `instance-options.md` matches current `src/config.py` validation rules
- [ ] Validation command runs from repo root: `.venv/bin/python -c "import asyncio; from src.config import load_config, load_instances; asyncio.run(load_instances(load_config()))"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)